### PR TITLE
feat: seed postfiat + prospect pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ pf-scout add "Allen Day" --identifier github:allenday
 # Seed from a GitHub org (discovers + collects all contributors)
 pf-scout seed github --org postfiatorg --token $GITHUB_TOKEN
 
+# Seed from Post Fiat leaderboard
+export PF_JWT_TOKEN=your-jwt-token
+pf-scout seed postfiat
+
+# Generate a prospect pipeline (live mode — no DB needed)
+pf-scout prospect --jwt $PF_JWT_TOKEN --output prospects.md
+
+# Generate from stored DB data
+pf-scout prospect --from-db --output prospects.md
+
 # View a contact card
 pf-scout show github:allenday
 
@@ -56,6 +66,8 @@ pf-scout report --rubric rubrics/b1e55ed.yaml --output prospects.md
 | `pf-scout show` | Display contact card |
 | `pf-scout list` | List contacts with optional tier filter |
 | `pf-scout seed github` | Seed contacts from GitHub org |
+| `pf-scout seed postfiat` | Seed contacts from PF leaderboard |
+| `pf-scout prospect` | Generate scored prospect pipeline doc |
 | `pf-scout update` | Re-collect signals + score interactively |
 | `pf-scout report` | Generate markdown/CSV report |
 | `pf-scout doctor` | Diagnostic: DB integrity, env vars, rubric |

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -14,7 +14,36 @@ pf-scout update github:allenday
 
 Auth: GitHub Personal Access Token with `read:org` + `read:user` scopes.
 
-## PostFiat (bundled)
+## PostFiat Leaderboard (bundled)
+
+Collects: `postfiat/leaderboard`
+
+```bash
+export PF_JWT_TOKEN=your-jwt-token
+pf-scout seed postfiat
+```
+
+Auth: JWT Bearer token from tasknode. Pass via `--jwt` or `PF_JWT_TOKEN` env var.
+
+**API endpoint:** `GET https://tasknode.postfiat.org/api/leaderboard`
+
+**Payload fields:**
+- `wallet_address` — XRPL wallet
+- `summary` — contributor description
+- `capabilities` — list of skills (str or dict)
+- `expert_knowledge` — list of `{domain: str}`
+- `monthly_rewards`, `weekly_rewards` — PFT earned
+- `monthly_tasks` — tasks completed this month
+- `alignment_score`, `alignment_tier` — protocol alignment metrics
+- `sybil_score`, `sybil_risk` — identity verification confidence
+- `leaderboard_score_month`, `leaderboard_score_week` — composite scores
+- `is_published`, `user_id` — account metadata
+
+**Dedup:** Content-addressed via event fingerprint. Re-running is safe — only new/changed data creates new signals.
+
+---
+
+## PostFiat Context (bundled)
 
 Collects: `postfiat/context`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,28 @@ pf-scout seed github --org postfiatorg
 ```
 Discovers all org contributors, creates contact records, and collects profile + commit signals.
 
-## 3. View a contact
+## 3. Seed from Post Fiat leaderboard
+```bash
+export PF_JWT_TOKEN=your-jwt-token
+pf-scout seed postfiat
+# Optional filters:
+pf-scout seed postfiat --min-alignment 70 --min-monthly-pft 50000
+```
+Fetches all contributors from the PF leaderboard API, creates contact records, and stores leaderboard signals.
+
+## 4. Generate a prospect pipeline
+```bash
+# Live mode (fetches leaderboard directly, no DB needed)
+pf-scout prospect --jwt $PF_JWT_TOKEN --output prospects.md
+
+# DB mode (uses stored signals from seed postfiat)
+pf-scout prospect --from-db --output prospects.md
+
+# Custom rubric
+pf-scout prospect --rubric rubrics/pf-default.yaml --jwt $PF_JWT_TOKEN --output prospects.md
+```
+
+## 5. View a contact
 ```bash
 pf-scout show github:allenday
 ```

--- a/pf_scout/cli.py
+++ b/pf_scout/cli.py
@@ -13,6 +13,7 @@ from .commands.doctor import doctor_command
 from .commands.set_context import set_context_cmd
 from .commands.rerank import rerank_cmd
 from .commands.wizard import wizard_cmd
+from .commands.prospect import prospect_cmd
 
 DEFAULT_DB = os.path.expanduser("~/.pf-scout/contacts.db")
 
@@ -38,6 +39,7 @@ cli.add_command(doctor_command)
 cli.add_command(set_context_cmd)
 cli.add_command(rerank_cmd)
 cli.add_command(wizard_cmd)
+cli.add_command(prospect_cmd)
 
 
 def main():

--- a/pf_scout/commands/prospect.py
+++ b/pf_scout/commands/prospect.py
@@ -1,0 +1,420 @@
+"""pf-scout prospect — generate a scored prospect pipeline document."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import click
+import requests
+import yaml
+
+from ..db import get_connection
+
+
+# ---------------------------------------------------------------------------
+# Default scoring dimensions (used when no rubric YAML provided)
+# ---------------------------------------------------------------------------
+
+TECH_KEYWORDS = [
+    "infrastructure", "devops", "backend", "engineering", "smart contract",
+    "blockchain", "solidity", "rust", "python", "go", "typescript",
+    "kubernetes", "docker", "cloud", "aws", "api", "protocol", "security",
+    "cryptography", "zk", "evm", "validator", "rpc",
+]
+
+QUANT_KEYWORDS = [
+    "quant", "quantitative", "machine learning", "ml", "statistics",
+    "trading", "signal", "forecasting", "data science", "analytics",
+    "on-chain", "onchain", "backtesting", "risk management", "portfolio",
+    "financial modeling", "time series", "alpha", "macro", "research",
+    "modeling", "prediction", "probability",
+]
+
+DEFAULT_DIMENSIONS = [
+    {"key": "technical_depth", "label": "Technical Depth", "weight": 1},
+    {"key": "forecasting", "label": "Forecasting / Quantitative Potential", "weight": 1},
+    {"key": "operational_reliability", "label": "Operational Reliability", "weight": 1},
+    {"key": "engagement_consistency", "label": "Engagement Consistency", "weight": 1},
+]
+
+
+def _text_blob(row: dict) -> str:
+    """Concatenate all text fields from a leaderboard row for keyword search."""
+    parts = []
+    if row.get("summary"):
+        parts.append(str(row["summary"]))
+    for cap in row.get("capabilities") or []:
+        if isinstance(cap, dict):
+            parts.append(" ".join(str(v) for v in cap.values()))
+        else:
+            parts.append(str(cap))
+    for ek in row.get("expert_knowledge") or []:
+        if isinstance(ek, dict):
+            parts.append(" ".join(str(v) for v in ek.values()))
+        else:
+            parts.append(str(ek))
+    return " ".join(parts).lower()
+
+
+def _count_keyword_hits(text: str, keywords: list[str]) -> int:
+    """Count how many distinct keywords appear in text."""
+    return sum(1 for kw in keywords if kw in text)
+
+
+def _hits_to_base(hits: int) -> int:
+    if hits == 0:
+        return 1
+    if hits == 1:
+        return 2
+    if hits == 2:
+        return 3
+    if hits <= 4:
+        return 4
+    return 5
+
+
+def score_technical_depth(row: dict) -> int:
+    text = _text_blob(row)
+    base = _hits_to_base(_count_keyword_hits(text, TECH_KEYWORDS))
+    if (row.get("sybil_score") or 0) >= 85:
+        base += 1
+    return min(base, 5)
+
+
+def score_forecasting(row: dict) -> int:
+    text = _text_blob(row)
+    base = _hits_to_base(_count_keyword_hits(text, QUANT_KEYWORDS))
+    if (row.get("alignment_score") or 0) >= 90:
+        base += 1
+    if (row.get("monthly_rewards") or 0) > 500000:
+        base += 1
+    return min(base, 5)
+
+
+def score_operational_reliability(row: dict) -> int:
+    lsm = row.get("leaderboard_score_month") or 0
+    if lsm < 15:
+        base = 1
+    elif lsm < 40:
+        base = 2
+    elif lsm < 60:
+        base = 3
+    elif lsm < 80:
+        base = 4
+    else:
+        base = 5
+    if (row.get("monthly_tasks") or 0) >= 30:
+        base += 1
+    monthly = row.get("monthly_rewards") or 0
+    weekly = row.get("weekly_rewards") or 0
+    if monthly > 0:
+        ratio = weekly / monthly
+        if 0.2 <= ratio <= 0.35:
+            base += 1
+    return min(base, 5)
+
+
+def score_engagement_consistency(row: dict) -> int:
+    weekly = row.get("weekly_rewards") or 0
+    if weekly <= 0:
+        base = 1
+    elif weekly <= 50000:
+        base = 2
+    elif weekly <= 150000:
+        base = 3
+    elif weekly <= 300000:
+        base = 4
+    else:
+        base = 5
+    if (row.get("leaderboard_score_week") or 0) > 50:
+        base += 1
+    return min(base, 5)
+
+
+SCORERS = {
+    "technical_depth": score_technical_depth,
+    "forecasting": score_forecasting,
+    "operational_reliability": score_operational_reliability,
+    "engagement_consistency": score_engagement_consistency,
+}
+
+
+def score_row(row: dict, dimensions: list[dict]) -> dict:
+    """Score a single leaderboard row against the given dimensions."""
+    scores = {}
+    for dim in dimensions:
+        key = dim["key"]
+        scorer = SCORERS.get(key)
+        scores[key] = scorer(row) if scorer else 1
+    composite = sum(scores.values())
+    max_possible = len(dimensions) * 5
+    pct = composite / max_possible if max_possible else 0
+    if pct >= 0.8:
+        tier = "🔴 Top Tier"
+    elif pct >= 0.6:
+        tier = "🟡 Mid Tier"
+    else:
+        tier = "⚪ Speculative"
+    return {
+        "scores": scores,
+        "composite": composite,
+        "max": max_possible,
+        "pct": pct,
+        "tier": tier,
+    }
+
+
+def _evidence_sentence(row: dict, dim_key: str) -> str:
+    """Generate a brief evidence sentence for a dimension score."""
+    text = _text_blob(row)
+    if dim_key == "technical_depth":
+        hits = [kw for kw in TECH_KEYWORDS if kw in text]
+        if hits:
+            return f"Keywords matched: {', '.join(hits[:5])}."
+        return "No technical keywords found in profile."
+    if dim_key == "forecasting":
+        hits = [kw for kw in QUANT_KEYWORDS if kw in text]
+        if hits:
+            return f"Keywords matched: {', '.join(hits[:5])}."
+        return "No quantitative keywords found in profile."
+    if dim_key == "operational_reliability":
+        lsm = row.get("leaderboard_score_month") or 0
+        mt = row.get("monthly_tasks") or 0
+        return f"Leaderboard score (month): {lsm}, monthly tasks: {mt}."
+    if dim_key == "engagement_consistency":
+        wr = row.get("weekly_rewards") or 0
+        lsw = row.get("leaderboard_score_week") or 0
+        return f"Weekly rewards: {wr:,.0f}, leaderboard score (week): {lsw}."
+    return "No evidence available."
+
+
+def _infer_role(row: dict) -> str:
+    text = _text_blob(row)
+    if any(kw in text for kw in ["trading", "quant", "alpha", "signal"]):
+        return "Signal / Quant"
+    if any(kw in text for kw in ["infrastructure", "devops", "kubernetes", "docker"]):
+        return "Infrastructure"
+    if any(kw in text for kw in ["smart contract", "solidity", "evm", "blockchain"]):
+        return "Protocol Engineer"
+    if any(kw in text for kw in ["research", "analytics", "data science"]):
+        return "Researcher"
+    return "Contributor"
+
+
+def _fetch_leaderboard(jwt: str, base_url: str) -> list[dict]:
+    resp = requests.get(
+        f"{base_url}/api/leaderboard",
+        headers={
+            "Authorization": f"Bearer {jwt}",
+            "User-Agent": "pf-scout/0.1.0",
+        },
+        timeout=15,
+    )
+    resp.raise_for_status()
+    return resp.json().get("rows", [])
+
+
+def _load_from_db(db_path: str) -> list[dict]:
+    conn = get_connection(db_path)
+    rows = conn.execute(
+        "SELECT payload FROM signals WHERE signal_type = 'postfiat/leaderboard' "
+        "ORDER BY collected_at DESC"
+    ).fetchall()
+    conn.close()
+    # Deduplicate by wallet
+    seen = set()
+    result = []
+    for r in rows:
+        payload = json.loads(r["payload"])
+        wallet = payload.get("wallet_address")
+        if wallet and wallet not in seen:
+            seen.add(wallet)
+            result.append(payload)
+    return result
+
+
+def _load_rubric(rubric_path: str) -> tuple[str, list[dict]]:
+    with open(rubric_path) as f:
+        rubric = yaml.safe_load(f)
+    name = rubric.get("name", Path(rubric_path).stem)
+    dims = []
+    for d in rubric.get("dimensions", []):
+        dims.append({
+            "key": d["key"],
+            "label": d.get("label", d["key"]),
+            "weight": d.get("weight", 1),
+            "description": d.get("guide", ""),
+        })
+    return name, dims
+
+
+def generate_document(
+    rows: list[dict],
+    dimensions: list[dict],
+    rubric_name: str,
+    title: str,
+    min_composite: int,
+) -> str:
+    """Score all rows and generate the markdown pipeline document."""
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    scored = []
+    for row in rows:
+        result = score_row(row, dimensions)
+        if result["composite"] < min_composite:
+            continue
+        label = row.get("summary") or row.get("wallet_address", "unknown")
+        wallet = row.get("wallet_address", "")
+        role = _infer_role(row)
+        scored.append({
+            "label": label,
+            "wallet": wallet,
+            "role": role,
+            "row": row,
+            **result,
+        })
+
+    scored.sort(key=lambda x: x["composite"], reverse=True)
+
+    tier_counts = {}
+    for s in scored:
+        tier_counts[s["tier"]] = tier_counts.get(s["tier"], 0) + 1
+
+    lines = []
+    lines.append(f"# {title} — Prospect Pipeline\n")
+    lines.append(
+        f"*Generated {today} | {len(scored)} contributors scored | Rubric: {rubric_name}*\n"
+    )
+    lines.append("---\n")
+
+    # Executive Summary
+    lines.append("## Executive Summary\n")
+    tier_summary = ", ".join(f"{v} {k}" for k, v in tier_counts.items())
+    top3 = scored[:3]
+    top3_text = "; ".join(
+        f"**{s['label']}** ({s['composite']}/{s['max']}, {s['role']})"
+        for s in top3
+    )
+    lines.append(
+        f"Scored {len(scored)} contributors across {len(dimensions)} dimensions. "
+        f"Distribution: {tier_summary}. "
+        f"Top 3: {top3_text}.\n"
+    )
+    lines.append("---\n")
+
+    # Rubric table
+    lines.append("## Scoring Rubric\n")
+    lines.append("| Dimension | Weight | Description | Signal Sources |")
+    lines.append("|-----------|--------|-------------|----------------|")
+    for d in dimensions:
+        desc = d.get("description", "").split("\n")[0].strip() or d["label"]
+        lines.append(f"| {d['label']} | {d.get('weight', 1)} | {desc} | Leaderboard data |")
+    lines.append("")
+    lines.append("---\n")
+
+    # Scored Prospect Table
+    lines.append("## Scored Prospect Table\n")
+    dim_headers = " | ".join(d["label"] for d in dimensions)
+    lines.append(f"| # | Contributor | Identifier | {dim_headers} | Composite | Role | Priority |")
+    sep = " | ".join("---" for _ in dimensions)
+    lines.append(f"|---|-------------|------------|{sep}|-----------|------|----------|")
+    for i, s in enumerate(scored, 1):
+        dim_vals = " | ".join(str(s["scores"].get(d["key"], "-")) for d in dimensions)
+        ident = f"`{s['wallet'][:12]}…`" if len(s["wallet"]) > 12 else f"`{s['wallet']}`"
+        lines.append(
+            f"| {i} | {s['label']} | {ident} | {dim_vals} | "
+            f"{s['composite']}/{s['max']} | {s['role']} | {s['tier']} |"
+        )
+    lines.append("")
+    lines.append("---\n")
+
+    # Prospect Profiles
+    lines.append("## Prospect Profiles\n")
+    for i, s in enumerate(scored, 1):
+        ident = s["wallet"]
+        lines.append(f"### {i}. {s['label']}")
+        lines.append(f"**Identifier:** `{ident}`")
+        dim_summary = " · ".join(
+            f"{d['label']}: {s['scores'].get(d['key'], '-')}"
+            for d in dimensions
+        )
+        lines.append(f"**Composite:** {s['composite']}/{s['max']} | {dim_summary}")
+        lines.append(f"**Tier:** {s['tier']}\n")
+
+        for d in dimensions:
+            score_val = s["scores"].get(d["key"], "-")
+            evidence = _evidence_sentence(s["row"], d["key"])
+            lines.append(f"**{d['label']} ({score_val}/5):** {evidence}\n")
+
+        # Assessment
+        lines.append(
+            f"**Assessment:** {s['label']} scores {s['composite']}/{s['max']} "
+            f"({s['pct']:.0%}), placing in {s['tier']}. "
+            f"Primary fit: {s['role']}.\n"
+        )
+
+        if "Top Tier" in s["tier"]:
+            lines.append(
+                f"**Recruitment angle:** Strong candidate for {s['role']} role. "
+                f"Demonstrated consistent engagement and relevant skills "
+                f"based on leaderboard performance.\n"
+            )
+
+        lines.append(
+            "**Gaps:** On-chain leaderboard data only; "
+            "no external portfolio, interview, or direct communication signal yet.\n"
+        )
+        lines.append("---\n")
+
+    return "\n".join(lines)
+
+
+@click.command("prospect")
+@click.option("--rubric", "rubric_path", type=click.Path(exists=True), default=None,
+              help="Rubric YAML file (default: built-in 4-dimension)")
+@click.option("--jwt", default=None, envvar="PF_JWT_TOKEN",
+              help="JWT token for live leaderboard fetch")
+@click.option("--output", "output_path", type=click.Path(), default=None,
+              help="Output file (default: stdout)")
+@click.option("--from-db", "from_db", is_flag=True, default=False,
+              help="Read from local DB instead of live API")
+@click.option("--min-composite", type=int, default=0,
+              help="Minimum composite score to include")
+@click.option("--title", default="Post Fiat",
+              help="Document title prefix")
+@click.option("--base-url", default="https://tasknode.postfiat.org",
+              help="Tasknode API base URL")
+@click.pass_context
+def prospect_cmd(ctx, rubric_path, jwt, output_path, from_db, min_composite, title, base_url):
+    """Generate a scored prospect pipeline document."""
+    # Load dimensions
+    if rubric_path:
+        rubric_name, dimensions = _load_rubric(rubric_path)
+    else:
+        rubric_name = "pf-default (4-dimension)"
+        dimensions = DEFAULT_DIMENSIONS
+
+    # Load data
+    if from_db:
+        db_path = ctx.obj["db_path"]
+        rows = _load_from_db(db_path)
+        if not rows:
+            raise click.ClickException(
+                "No postfiat/leaderboard signals in DB. Run: pf-scout seed postfiat first."
+            )
+        click.echo(f"Loaded {len(rows)} contributors from DB")
+    else:
+        if not jwt:
+            raise click.ClickException(
+                "JWT required for live mode. Pass --jwt or set PF_JWT_TOKEN, "
+                "or use --from-db for stored data."
+            )
+        rows = _fetch_leaderboard(jwt, base_url)
+        click.echo(f"Fetched {len(rows)} contributors from leaderboard")
+
+    doc = generate_document(rows, dimensions, rubric_name, title, min_composite)
+
+    if output_path:
+        Path(output_path).write_text(doc)
+        click.echo(f"Wrote prospect pipeline to {output_path}")
+    else:
+        click.echo(doc)

--- a/pf_scout/commands/seed.py
+++ b/pf_scout/commands/seed.py
@@ -9,12 +9,16 @@ import click
 from ..db import get_connection
 from ..fingerprint import compute_event_fingerprint
 from ..collectors.github import GitHubCollector
+from .seed_postfiat import seed_postfiat
 
 
 @click.group("seed")
 def seed_group():
     """Seed contacts from external sources."""
     pass
+
+
+seed_group.add_command(seed_postfiat)
 
 
 @seed_group.command("github")

--- a/pf_scout/commands/seed_postfiat.py
+++ b/pf_scout/commands/seed_postfiat.py
@@ -1,0 +1,162 @@
+"""pf-scout seed postfiat — seed contacts from the Post Fiat leaderboard API."""
+
+import json
+import uuid
+from datetime import datetime
+
+import click
+import requests
+
+from ..db import get_connection
+from ..fingerprint import compute_event_fingerprint
+
+
+@click.command("postfiat")
+@click.option("--jwt", default=None, envvar="PF_JWT_TOKEN",
+              help="JWT token for PF leaderboard API (or set PF_JWT_TOKEN)")
+@click.option("--min-alignment", type=float, default=None,
+              help="Minimum alignment_score to include")
+@click.option("--min-monthly-pft", type=float, default=None,
+              help="Minimum monthly_rewards to include")
+@click.option("--base-url", default="https://tasknode.postfiat.org",
+              help="Tasknode API base URL")
+@click.pass_context
+def seed_postfiat(ctx, jwt, min_alignment, min_monthly_pft, base_url):
+    """Seed contacts from the Post Fiat leaderboard API."""
+    if not jwt:
+        raise click.ClickException(
+            "JWT token required. Pass --jwt or set PF_JWT_TOKEN env var."
+        )
+
+    db_path = ctx.obj["db_path"]
+    conn = get_connection(db_path)
+
+    contacts_created = 0
+    signals_inserted = 0
+    skipped = 0
+
+    try:
+        click.echo("Fetching Post Fiat leaderboard...")
+        resp = requests.get(
+            f"{base_url}/api/leaderboard",
+            headers={
+                "Authorization": f"Bearer {jwt}",
+                "User-Agent": "pf-scout/0.1.0",
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        rows = data.get("rows", [])
+        click.echo(f"Found {len(rows)} contributors on leaderboard")
+
+        for row in rows:
+            wallet = row.get("wallet_address", "")
+            if not wallet:
+                continue
+
+            # Apply filters
+            if min_alignment is not None:
+                if (row.get("alignment_score") or 0) < min_alignment:
+                    skipped += 1
+                    continue
+            if min_monthly_pft is not None:
+                if (row.get("monthly_rewards") or 0) < min_monthly_pft:
+                    skipped += 1
+                    continue
+
+            now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            label = row.get("summary") or wallet
+
+            # Check if identifier already exists
+            existing = conn.execute(
+                "SELECT id, contact_id FROM identifiers "
+                "WHERE platform = ? AND identifier_value = ?",
+                ("postfiat", wallet),
+            ).fetchone()
+
+            if existing:
+                contact_id = existing["contact_id"]
+                ident_id = existing["id"]
+            else:
+                # Create new contact + identifier
+                contact_id = str(uuid.uuid4())
+                ident_id = str(uuid.uuid4())
+
+                conn.execute(
+                    "INSERT INTO contacts (id, canonical_label, first_seen, last_updated) "
+                    "VALUES (?, ?, ?, ?)",
+                    (contact_id, label, now, now),
+                )
+                conn.execute(
+                    "INSERT INTO identifiers "
+                    "(id, contact_id, platform, identifier_value, is_primary, "
+                    "first_seen, last_seen, link_confidence, link_source) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (ident_id, contact_id, "postfiat", wallet, 1, now, now, 1.0, "seed"),
+                )
+                contacts_created += 1
+
+            # Insert leaderboard signal
+            payload = {
+                "wallet_address": wallet,
+                "summary": row.get("summary"),
+                "capabilities": row.get("capabilities", []),
+                "expert_knowledge": row.get("expert_knowledge", []),
+                "monthly_rewards": row.get("monthly_rewards"),
+                "monthly_tasks": row.get("monthly_tasks"),
+                "weekly_rewards": row.get("weekly_rewards"),
+                "alignment_score": row.get("alignment_score"),
+                "alignment_tier": row.get("alignment_tier"),
+                "sybil_score": row.get("sybil_score"),
+                "sybil_risk": row.get("sybil_risk"),
+                "leaderboard_score_month": row.get("leaderboard_score_month"),
+                "leaderboard_score_week": row.get("leaderboard_score_week"),
+                "is_published": row.get("is_published"),
+                "user_id": row.get("user_id"),
+            }
+
+            fingerprint = compute_event_fingerprint(
+                contact_id, "postfiat", "postfiat/leaderboard",
+                wallet, payload,
+            )
+
+            payload_json = json.dumps(payload, sort_keys=True, ensure_ascii=True)
+
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO signals "
+                "(contact_id, identifier_id, collected_at, signal_ts, source, signal_type, "
+                "source_event_id, event_fingerprint, payload, evidence_note) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    contact_id, ident_id, now, now, "postfiat", "postfiat/leaderboard",
+                    wallet, fingerprint, payload_json,
+                    f"PF leaderboard: {label}",
+                ),
+            )
+            if cursor.rowcount > 0:
+                signals_inserted += 1
+
+            # Update timestamps
+            conn.execute(
+                "UPDATE identifiers SET last_seen = ? WHERE id = ?", (now, ident_id)
+            )
+            conn.execute(
+                "UPDATE contacts SET last_updated = ? WHERE id = ?", (now, contact_id)
+            )
+
+        conn.commit()
+        click.echo(
+            f"Seeded {contacts_created} contacts, {signals_inserted} signals "
+            f"from postfiat leaderboard"
+            + (f" ({skipped} filtered out)" if skipped else "")
+        )
+
+    except requests.RequestException as e:
+        conn.rollback()
+        raise click.ClickException(f"Leaderboard API error: {e}")
+    except Exception as e:
+        conn.rollback()
+        raise click.ClickException(str(e))
+    finally:
+        conn.close()

--- a/rubrics/pf-default.yaml
+++ b/rubrics/pf-default.yaml
@@ -1,0 +1,55 @@
+name: pf-default
+version: "1.0"
+description: >
+  Generic 4-dimension rubric for Post Fiat contributor assessment.
+  Covers technical capability, quantitative potential, operational track record,
+  and engagement consistency. Suitable for any PF node operator.
+
+tiers:
+  - name: "🔴 Top Tier"
+    min_pct: 0.80
+    description: "Strong prospect — prioritize outreach"
+  - name: "🟡 Mid Tier"
+    min_pct: 0.60
+    description: "Promising — monitor and engage"
+  - name: "⚪ Speculative"
+    min_pct: 0.0
+    description: "Early signal — needs more data"
+
+dimensions:
+  - key: technical_depth
+    label: "Technical Depth"
+    weight: 1
+    guide: |
+      Keyword search across capabilities, expert_knowledge, and summary.
+      Keywords: infrastructure, devops, backend, engineering, smart contract,
+      blockchain, solidity, rust, python, go, typescript, kubernetes, docker,
+      cloud, aws, api, protocol, security, cryptography, zk, evm, validator, rpc.
+      0 hits→1, 1→2, 2→3, 3-4→4, 5+→5. Bonus +1 if sybil_score >= 85.
+
+  - key: forecasting
+    label: "Forecasting / Quantitative Potential"
+    weight: 1
+    guide: |
+      Keyword search across capabilities, expert_knowledge, and summary.
+      Keywords: quant, quantitative, machine learning, ml, statistics, trading,
+      signal, forecasting, data science, analytics, on-chain, onchain, backtesting,
+      risk management, portfolio, financial modeling, time series, alpha, macro,
+      research, modeling, prediction, probability.
+      0→1, 1→2, 2→3, 3-4→4, 5+→5. Bonus +1 if alignment_score >= 90.
+      Bonus +1 if monthly_rewards > 500,000.
+
+  - key: operational_reliability
+    label: "Operational Reliability"
+    weight: 1
+    guide: |
+      Based on leaderboard_score_month: <15→1, 15-39→2, 40-59→3, 60-79→4, >=80→5.
+      Bonus +1 if monthly_tasks >= 30. Bonus +1 if weekly/monthly reward ratio
+      is between 0.2 and 0.35.
+
+  - key: engagement_consistency
+    label: "Engagement Consistency"
+    weight: 1
+    guide: |
+      Based on weekly_rewards: 0→1, >0→2, >50000→3, >150000→4, >300000→5.
+      Bonus +1 if leaderboard_score_week > 50.

--- a/tests/test_prospect.py
+++ b/tests/test_prospect.py
@@ -1,0 +1,194 @@
+"""Tests for the prospect pipeline scoring and document generation."""
+
+from pf_scout.commands.prospect import (
+    DEFAULT_DIMENSIONS,
+    generate_document,
+    score_engagement_consistency,
+    score_forecasting,
+    score_operational_reliability,
+    score_row,
+    score_technical_depth,
+)
+
+
+def _make_row(**overrides):
+    """Create a mock leaderboard row with sensible defaults."""
+    row = {
+        "wallet_address": "rMockWallet123",
+        "summary": "A contributor",
+        "capabilities": [],
+        "expert_knowledge": [],
+        "monthly_rewards": 100000,
+        "monthly_tasks": 10,
+        "weekly_rewards": 25000,
+        "alignment_score": 70,
+        "alignment_tier": "medium",
+        "sybil_score": 60,
+        "sybil_risk": "low",
+        "leaderboard_score_month": 50,
+        "leaderboard_score_week": 30,
+        "is_published": True,
+        "user_id": "user-1",
+    }
+    row.update(overrides)
+    return row
+
+
+class TestScoringDimensions:
+    """Test individual dimension scoring functions."""
+
+    def test_technical_depth_no_keywords(self):
+        row = _make_row(capabilities=[], expert_knowledge=[], summary="hello")
+        assert score_technical_depth(row) == 1
+
+    def test_technical_depth_many_keywords(self):
+        row = _make_row(
+            capabilities=["python", "rust", "docker", "kubernetes", "aws", "solidity"],
+            summary="blockchain infrastructure engineer",
+        )
+        score = score_technical_depth(row)
+        assert score >= 4
+
+    def test_technical_depth_sybil_bonus(self):
+        row = _make_row(capabilities=["python"], sybil_score=90)
+        score_with_bonus = score_technical_depth(row)
+        row2 = _make_row(capabilities=["python"], sybil_score=50)
+        score_without = score_technical_depth(row2)
+        assert score_with_bonus >= score_without
+
+    def test_forecasting_no_keywords(self):
+        row = _make_row(capabilities=[], summary="gardener")
+        assert score_forecasting(row) == 1
+
+    def test_forecasting_with_keywords_and_bonuses(self):
+        row = _make_row(
+            capabilities=["quant", "machine learning", "trading", "backtesting", "signal"],
+            alignment_score=95,
+            monthly_rewards=600000,
+        )
+        assert score_forecasting(row) == 5  # capped
+
+    def test_operational_reliability_low_score(self):
+        row = _make_row(leaderboard_score_month=10, monthly_tasks=5, weekly_rewards=0)
+        assert score_operational_reliability(row) == 1
+
+    def test_operational_reliability_high_score(self):
+        row = _make_row(
+            leaderboard_score_month=85,
+            monthly_tasks=35,
+            monthly_rewards=100000,
+            weekly_rewards=25000,  # ratio = 0.25
+        )
+        score = score_operational_reliability(row)
+        assert score == 5  # 5 base + 1 tasks + 1 ratio = 7 → capped at 5
+
+    def test_engagement_consistency_zero_weekly(self):
+        row = _make_row(weekly_rewards=0)
+        assert score_engagement_consistency(row) == 1
+
+    def test_engagement_consistency_high(self):
+        row = _make_row(weekly_rewards=400000, leaderboard_score_week=60)
+        assert score_engagement_consistency(row) == 5  # 5 + 1 → capped
+
+
+class TestCompositeAndTiers:
+    """Test composite scoring and tier assignment."""
+
+    def test_composite_is_sum_of_dimensions(self):
+        row = _make_row(
+            capabilities=["python", "rust"],
+            leaderboard_score_month=50,
+            weekly_rewards=100000,
+        )
+        result = score_row(row, DEFAULT_DIMENSIONS)
+        expected_sum = sum(result["scores"].values())
+        assert result["composite"] == expected_sum
+
+    def test_max_is_dimensions_times_five(self):
+        row = _make_row()
+        result = score_row(row, DEFAULT_DIMENSIONS)
+        assert result["max"] == len(DEFAULT_DIMENSIONS) * 5
+
+    def test_top_tier_threshold(self):
+        # Force high scores everywhere
+        row = _make_row(
+            capabilities=[
+                "python", "rust", "docker", "kubernetes", "aws", "solidity",
+                "quant", "machine learning", "trading", "backtesting", "signal",
+            ],
+            summary="blockchain infrastructure quant engineer",
+            sybil_score=90,
+            alignment_score=95,
+            monthly_rewards=600000,
+            leaderboard_score_month=90,
+            monthly_tasks=40,
+            weekly_rewards=400000,
+            leaderboard_score_week=60,
+        )
+        result = score_row(row, DEFAULT_DIMENSIONS)
+        assert result["tier"] == "🔴 Top Tier"
+
+    def test_speculative_tier(self):
+        row = _make_row(
+            capabilities=[],
+            summary="newbie",
+            leaderboard_score_month=5,
+            monthly_tasks=2,
+            weekly_rewards=0,
+        )
+        result = score_row(row, DEFAULT_DIMENSIONS)
+        assert result["tier"] == "⚪ Speculative"
+
+    def test_mid_tier(self):
+        # Medium scores: need composite/max >= 0.6 but < 0.8
+        # Max = 20, so need 12-15
+        row = _make_row(
+            capabilities=["python", "rust", "docker"],
+            summary="engineer with trading experience",
+            leaderboard_score_month=60,
+            monthly_tasks=20,
+            weekly_rewards=100000,
+            leaderboard_score_week=30,
+        )
+        result = score_row(row, DEFAULT_DIMENSIONS)
+        assert result["tier"] in ("🟡 Mid Tier", "🔴 Top Tier")
+
+
+class TestDocumentGeneration:
+    """Test that the output document contains required sections."""
+
+    def test_document_has_required_sections(self):
+        rows = [
+            _make_row(
+                wallet_address="rWallet1",
+                summary="Alice",
+                capabilities=["python"],
+                leaderboard_score_month=50,
+                weekly_rewards=100000,
+            ),
+            _make_row(
+                wallet_address="rWallet2",
+                summary="Bob",
+                capabilities=["rust", "docker"],
+                leaderboard_score_month=70,
+                weekly_rewards=200000,
+            ),
+        ]
+        doc = generate_document(rows, DEFAULT_DIMENSIONS, "test-rubric", "Test", 0)
+
+        assert "## Executive Summary" in doc
+        assert "## Scoring Rubric" in doc
+        assert "## Scored Prospect Table" in doc
+        assert "## Prospect Profiles" in doc
+
+    def test_document_contains_contributors(self):
+        rows = [_make_row(wallet_address="rW1", summary="Charlie")]
+        doc = generate_document(rows, DEFAULT_DIMENSIONS, "test", "Test", 0)
+        assert "Charlie" in doc
+        assert "rW1" in doc
+
+    def test_min_composite_filters(self):
+        rows = [_make_row(summary="LowScorer", capabilities=[], weekly_rewards=0,
+                          leaderboard_score_month=5)]
+        doc = generate_document(rows, DEFAULT_DIMENSIONS, "test", "Test", 99)
+        assert "LowScorer" not in doc


### PR DESCRIPTION
## What

Two new commands for any PF node operator:

### `pf-scout seed postfiat`
Seeds contacts from the Post Fiat leaderboard API (JWT Bearer auth). Follows same DB/signal patterns as `seed github`.

### `pf-scout prospect`
Generates a scored prospect pipeline document. Works in two modes:
- **Live** (default): fetch leaderboard → score → write doc, no DB needed
- **DB** (`--from-db`): reads stored contacts/signals

Supports any rubric via `--rubric`. Defaults to new `pf-default.yaml` (4 dimensions). Output format is generic — not product-specific.

## Changes
- `pf_scout/commands/seed_postfiat.py` — new
- `pf_scout/commands/prospect.py` — new
- `rubrics/pf-default.yaml` — new generic rubric
- `README.md`, `docs/quickstart.md`, `docs/collectors.md` — updated
- `tests/test_prospect.py` — new

## Type of change
- [x] New feature (non-breaking)

## Testing
- Ruff clean
- 36 pytest tests passing