### PR TITLE
Phase 1: Core UX Commands (#7, #8, #9, #10)

### DIFF
--- a/pf_scout/cli.py
+++ b/pf_scout/cli.py
@@ -14,6 +14,9 @@ from .commands.set_context import set_context_cmd
 from .commands.rerank import rerank_cmd
 from .commands.wizard import wizard_cmd
 from .commands.prospect import prospect_cmd
+from .commands.list import list_command
+from .commands.export import export_command
+from .commands.note import note_command
 
 DEFAULT_DB = os.path.expanduser("~/.pf-scout/contacts.db")
 
@@ -40,6 +43,9 @@ cli.add_command(set_context_cmd)
 cli.add_command(rerank_cmd)
 cli.add_command(wizard_cmd)
 cli.add_command(prospect_cmd)
+cli.add_command(list_command)
+cli.add_command(export_command)
+cli.add_command(note_command)
 
 
 def main():

--- a/pf_scout/commands/doctor.py
+++ b/pf_scout/commands/doctor.py
@@ -29,7 +29,7 @@ def doctor_command(ctx, rubric_path):
             ok = False
         else:
             click.echo("  ✅ Rubric is valid")
-        
+
         # When validating rubric only, show summary and exit
         if ok:
             click.echo("\n✅ Rubric validation passed")
@@ -39,7 +39,7 @@ def doctor_command(ctx, rubric_path):
         return
 
     # Standard doctor checks
-    
+
     # DB integrity
     click.echo("Checking DB integrity...")
     try:

--- a/pf_scout/commands/doctor.py
+++ b/pf_scout/commands/doctor.py
@@ -1,19 +1,45 @@
 """pf-scout doctor: diagnostic checks."""
 
 import os
+from pathlib import Path
 
 import click
 
 from ..db import get_connection
+from ..rubric import validate_rubric
 
 
 @click.command("doctor")
+@click.option("--rubric", "rubric_path", type=click.Path(exists=True), default=None,
+              help="Validate a rubric YAML file")
 @click.pass_context
-def doctor_command(ctx):
+def doctor_command(ctx, rubric_path):
     """Check DB integrity, collector env vars, rubric validity, schema version."""
     db_path = ctx.obj["db_path"]
     ok = True
 
+    # If --rubric is specified, validate that specific rubric
+    if rubric_path:
+        click.echo(f"Validating rubric: {rubric_path}")
+        errors = validate_rubric(rubric_path)
+        if errors:
+            click.echo("  ❌ Rubric validation failed:")
+            for err in errors:
+                click.echo(f"     • {err}")
+            ok = False
+        else:
+            click.echo("  ✅ Rubric is valid")
+        
+        # When validating rubric only, show summary and exit
+        if ok:
+            click.echo("\n✅ Rubric validation passed")
+        else:
+            click.echo("\n❌ Rubric validation failed")
+            ctx.exit(1)
+        return
+
+    # Standard doctor checks
+    
     # DB integrity
     click.echo("Checking DB integrity...")
     try:
@@ -47,6 +73,24 @@ def doctor_command(ctx):
             click.echo(f"  ✅ {name}: {var} set")
         else:
             click.echo(f"  ⚠️  {name}: {var} not set")
+
+    # Auto-validate rubrics in ./rubrics/ if they exist
+    rubrics_dir = Path("rubrics")
+    if rubrics_dir.exists() and rubrics_dir.is_dir():
+        click.echo("Checking rubrics...")
+        rubric_files = list(rubrics_dir.glob("*.yaml")) + list(rubrics_dir.glob("*.yml"))
+        if rubric_files:
+            for rf in rubric_files:
+                errors = validate_rubric(rf)
+                if errors:
+                    click.echo(f"  ❌ {rf.name}: {len(errors)} error(s)")
+                    for err in errors[:3]:  # Show first 3 errors
+                        click.echo(f"     • {err}")
+                    ok = False
+                else:
+                    click.echo(f"  ✅ {rf.name}: valid")
+        else:
+            click.echo("  ⚠️  No rubric files found in ./rubrics/")
 
     if ok:
         click.echo("\n✅ All checks passed")

--- a/pf_scout/commands/export.py
+++ b/pf_scout/commands/export.py
@@ -1,0 +1,182 @@
+"""pf-scout export command — export all contact data."""
+
+import hashlib
+import json
+from datetime import datetime
+
+import click
+
+from ..db import get_connection
+
+
+def anonymize_value(value: str, salt: str = "") -> str:
+    """Create a deterministic anonymous identifier."""
+    h = hashlib.sha256((salt + value).encode()).hexdigest()[:12]
+    return f"anon_{h}"
+
+
+@click.command("export")
+@click.option("--output", "-o", "output_path", type=click.Path(),
+              help="Output file path (defaults to stdout)")
+@click.option("--anonymize", is_flag=True,
+              help="Redact personal identifiers")
+@click.option("--include-private", is_flag=True,
+              help="Include private notes in export")
+@click.pass_context
+def export_command(ctx, output_path, anonymize, include_private):
+    """Export all contact data to JSON.
+
+    Exports contacts, identifiers, signals, snapshots, and notes.
+    Use --anonymize to redact personal identifiers for sharing.
+    Use --include-private to include private notes (excluded by default).
+    """
+    db_path = ctx.obj["db_path"]
+    conn = get_connection(db_path)
+
+    # Salt for anonymization (use db path as deterministic salt)
+    anon_salt = db_path if anonymize else ""
+
+    try:
+        export_data = {
+            "exported_at": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+            "anonymized": anonymize,
+            "include_private_notes": include_private,
+            "contacts": [],
+        }
+
+        # Fetch all contacts
+        contacts = conn.execute(
+            "SELECT * FROM contacts WHERE archived = 0 ORDER BY canonical_label"
+        ).fetchall()
+
+        for contact in contacts:
+            contact_id = contact["id"]
+
+            # Get identifiers
+            identifiers = conn.execute(
+                "SELECT * FROM identifiers WHERE contact_id = ?",
+                (contact_id,)
+            ).fetchall()
+
+            # Get signals
+            signals = conn.execute(
+                "SELECT * FROM signals WHERE contact_id = ? ORDER BY collected_at DESC",
+                (contact_id,)
+            ).fetchall()
+
+            # Get snapshots
+            snapshots = conn.execute(
+                "SELECT * FROM snapshots WHERE contact_id = ? ORDER BY snapshot_ts DESC",
+                (contact_id,)
+            ).fetchall()
+
+            # Get notes (filter private unless --include-private)
+            notes_query = "SELECT * FROM notes WHERE contact_id = ?"
+            if not include_private:
+                notes_query += " AND privacy_tier != 'private'"
+            notes_query += " ORDER BY note_ts DESC"
+            notes = conn.execute(notes_query, (contact_id,)).fetchall()
+
+            # Build contact export
+            contact_export = {
+                "id": anonymize_value(contact_id, anon_salt) if anonymize else contact_id,
+                "canonical_label": anonymize_value(contact["canonical_label"], anon_salt) if anonymize else contact["canonical_label"],
+                "first_seen": contact["first_seen"],
+                "last_updated": contact["last_updated"],
+                "tags": json.loads(contact["tags"]) if contact["tags"] else [],
+                "notes_count": contact["notes_count"],
+                "identifiers": [],
+                "signals": [],
+                "snapshots": [],
+                "notes": [],
+            }
+
+            # Export identifiers
+            for ident in identifiers:
+                ident_value = ident["identifier_value"]
+                if anonymize:
+                    ident_value = anonymize_value(ident_value, anon_salt)
+
+                contact_export["identifiers"].append({
+                    "id": anonymize_value(ident["id"], anon_salt) if anonymize else ident["id"],
+                    "platform": ident["platform"],
+                    "identifier_value": ident_value,
+                    "is_primary": bool(ident["is_primary"]),
+                    "link_confidence": ident["link_confidence"],
+                    "link_source": ident["link_source"],
+                    "first_seen": ident["first_seen"],
+                    "last_seen": ident["last_seen"],
+                })
+
+            # Export signals
+            for sig in signals:
+                payload = json.loads(sig["payload"]) if sig["payload"] else {}
+
+                # Anonymize payload if needed
+                if anonymize and payload:
+                    # Redact common PII fields
+                    for key in ["username", "login", "email", "name", "author", "user"]:
+                        if key in payload:
+                            payload[key] = anonymize_value(str(payload[key]), anon_salt)
+
+                contact_export["signals"].append({
+                    "id": sig["id"],
+                    "signal_type": sig["signal_type"],
+                    "source": sig["source"],
+                    "collected_at": sig["collected_at"],
+                    "signal_ts": sig["signal_ts"],
+                    "payload": payload,
+                    "evidence_note": sig["evidence_note"],
+                })
+
+            # Export snapshots
+            for snap in snapshots:
+                contact_export["snapshots"].append({
+                    "id": snap["id"],
+                    "snapshot_ts": snap["snapshot_ts"],
+                    "rubric_name": snap["rubric_name"],
+                    "rubric_version": snap["rubric_version"],
+                    "trigger": snap["trigger"],
+                    "dimension_scores": json.loads(snap["dimension_scores"]) if snap["dimension_scores"] else {},
+                    "total_score": snap["total_score"],
+                    "weighted_score": snap["weighted_score"],
+                    "tier": snap["tier"],
+                })
+
+            # Export notes
+            for note in notes:
+                note_body = note["body"]
+                if anonymize:
+                    # Simple anonymization — replace potential names/handles
+                    note_body = "[redacted note content]"
+
+                contact_export["notes"].append({
+                    "id": note["id"],
+                    "note_ts": note["note_ts"],
+                    "author": anonymize_value(note["author"], anon_salt) if anonymize else note["author"],
+                    "body": note_body,
+                    "privacy_tier": note["privacy_tier"],
+                })
+
+            export_data["contacts"].append(contact_export)
+
+        # Summary stats
+        export_data["summary"] = {
+            "total_contacts": len(export_data["contacts"]),
+            "total_signals": sum(len(c["signals"]) for c in export_data["contacts"]),
+            "total_snapshots": sum(len(c["snapshots"]) for c in export_data["contacts"]),
+            "total_notes": sum(len(c["notes"]) for c in export_data["contacts"]),
+        }
+
+        # Output
+        json_output = json.dumps(export_data, indent=2)
+
+        if output_path:
+            with open(output_path, "w") as f:
+                f.write(json_output)
+            click.echo(f"✓ Exported {len(export_data['contacts'])} contacts to {output_path}")
+        else:
+            click.echo(json_output)
+
+    finally:
+        conn.close()

--- a/pf_scout/commands/list.py
+++ b/pf_scout/commands/list.py
@@ -3,7 +3,6 @@
 import csv
 import io
 import json
-from pathlib import Path
 
 import click
 import yaml

--- a/pf_scout/commands/list.py
+++ b/pf_scout/commands/list.py
@@ -1,0 +1,158 @@
+"""pf-scout list command — show all contacts with latest scores."""
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import click
+import yaml
+
+from ..db import get_connection
+
+
+def load_rubric(rubric_path):
+    """Load a YAML rubric file."""
+    with open(rubric_path) as f:
+        return yaml.safe_load(f)
+
+
+@click.command("list")
+@click.option("--tier", type=click.Choice(["top", "mid", "speculative", "low"]),
+              help="Filter by tier")
+@click.option("--rubric", "rubric_path", type=click.Path(exists=True),
+              help="Use specific rubric for filtering")
+@click.option("--format", "output_format", type=click.Choice(["text", "json", "csv"]),
+              default="text", help="Output format")
+@click.option("--limit", type=int, default=None, help="Maximum number of contacts to show")
+@click.pass_context
+def list_command(ctx, tier, rubric_path, output_format, limit):
+    """List all contacts with their latest scores.
+
+    Shows contacts ordered by weighted score (descending).
+    Use --tier to filter by score tier, --format for different outputs.
+    """
+    db_path = ctx.obj["db_path"]
+    conn = get_connection(db_path)
+
+    rubric_name = None
+    if rubric_path:
+        rubric = load_rubric(rubric_path)
+        rubric_name = rubric.get("name")
+
+    try:
+        # Build query for contacts with latest snapshot
+        query = """
+            SELECT c.id, c.canonical_label, c.first_seen, c.last_updated,
+                   c.tags, c.notes_count, c.archived,
+                   s.weighted_score, s.total_score, s.tier, s.snapshot_ts, s.rubric_name
+            FROM contacts c
+            LEFT JOIN snapshots s ON s.id = (
+                SELECT id FROM snapshots
+                WHERE contact_id = c.id
+        """
+        params = []
+
+        if rubric_name:
+            query += " AND rubric_name = ?"
+            params.append(rubric_name)
+
+        query += """
+                ORDER BY snapshot_ts DESC LIMIT 1
+            )
+            WHERE c.archived = 0
+        """
+
+        # Filter by tier if specified
+        if tier:
+            query += " AND LOWER(s.tier) = ?"
+            params.append(tier.lower())
+
+        query += " ORDER BY s.weighted_score DESC NULLS LAST, c.canonical_label ASC"
+
+        if limit:
+            query += " LIMIT ?"
+            params.append(limit)
+
+        rows = conn.execute(query, params).fetchall()
+
+        # Get identifiers for each contact
+        results = []
+        for row in rows:
+            contact_id = row["id"]
+
+            # Get primary identifier
+            ident_row = conn.execute(
+                "SELECT platform, identifier_value FROM identifiers "
+                "WHERE contact_id = ? ORDER BY is_primary DESC LIMIT 1",
+                (contact_id,)
+            ).fetchone()
+
+            primary_ident = f"{ident_row['platform']}:{ident_row['identifier_value']}" if ident_row else "—"
+
+            results.append({
+                "id": contact_id,
+                "label": row["canonical_label"],
+                "primary_identifier": primary_ident,
+                "score": row["weighted_score"] or 0,
+                "total_score": row["total_score"] or 0,
+                "tier": row["tier"] or "—",
+                "rubric": row["rubric_name"] or "—",
+                "snapshot_ts": (row["snapshot_ts"] or "")[:10],
+                "last_updated": (row["last_updated"] or "")[:10],
+                "notes_count": row["notes_count"],
+                "tags": json.loads(row["tags"]) if row["tags"] else [],
+            })
+
+        # Output results
+        if output_format == "json":
+            click.echo(json.dumps(results, indent=2))
+
+        elif output_format == "csv":
+            output = io.StringIO()
+            writer = csv.DictWriter(output, fieldnames=[
+                "label", "primary_identifier", "tier", "score", "total_score",
+                "rubric", "snapshot_ts", "last_updated", "notes_count"
+            ])
+            writer.writeheader()
+            for r in results:
+                writer.writerow({
+                    "label": r["label"],
+                    "primary_identifier": r["primary_identifier"],
+                    "tier": r["tier"],
+                    "score": r["score"],
+                    "total_score": r["total_score"],
+                    "rubric": r["rubric"],
+                    "snapshot_ts": r["snapshot_ts"],
+                    "last_updated": r["last_updated"],
+                    "notes_count": r["notes_count"],
+                })
+            click.echo(output.getvalue().strip())
+
+        else:
+            # Text format
+            if not results:
+                click.echo("No contacts found.")
+                return
+
+            # Header
+            tier_filter = f" (tier: {tier})" if tier else ""
+            rubric_filter = f" (rubric: {rubric_name})" if rubric_name else ""
+            limit_info = f" (showing {len(results)})" if limit else f" ({len(results)} total)"
+            click.echo(f"\nContacts{tier_filter}{rubric_filter}{limit_info}\n")
+
+            click.echo(f"{'#':<4} {'Contact':<22} {'Identifier':<25} {'Tier':<12} {'Score':<7} {'Updated'}")
+            click.echo("─" * 85)
+
+            for i, r in enumerate(results, 1):
+                ident_display = r["primary_identifier"][:24] if len(r["primary_identifier"]) > 24 else r["primary_identifier"]
+                label_display = r["label"][:21] if len(r["label"]) > 21 else r["label"]
+                click.echo(
+                    f"{i:<4} {label_display:<22} {ident_display:<25} "
+                    f"{r['tier']:<12} {r['score']:<7.1f} {r['last_updated']}"
+                )
+
+            click.echo()
+
+    finally:
+        conn.close()

--- a/pf_scout/commands/note.py
+++ b/pf_scout/commands/note.py
@@ -1,0 +1,83 @@
+"""pf-scout note command — add notes to contacts."""
+
+from datetime import datetime
+
+import click
+
+from ..db import get_connection
+
+
+@click.command("note")
+@click.argument("identifier")
+@click.argument("text")
+@click.option("--private", is_flag=True,
+              help="Mark note as private (excluded from non-private exports)")
+@click.option("--author", default="user",
+              help="Author identifier for the note")
+@click.pass_context
+def note_command(ctx, identifier, text, private, author):
+    """Add a note to a contact.
+
+    IDENTIFIER should be in platform:value format (e.g., github:username).
+    TEXT is the note content.
+
+    Examples:
+        pf-scout note github:alice "Great contributor, very responsive"
+        pf-scout note github:bob "Sensitive info here" --private
+    """
+    db_path = ctx.obj["db_path"]
+    conn = get_connection(db_path)
+
+    try:
+        if ":" not in identifier:
+            raise click.ClickException("Identifier must be in platform:value format")
+
+        platform, _, value = identifier.partition(":")
+
+        # Find the identifier
+        ident_row = conn.execute(
+            "SELECT * FROM identifiers WHERE platform = ? AND identifier_value = ?",
+            (platform, value)
+        ).fetchone()
+
+        if not ident_row:
+            raise click.ClickException(f"Identifier not found: {identifier}")
+
+        contact_id = ident_row["contact_id"]
+
+        # Get contact for display
+        contact = conn.execute(
+            "SELECT * FROM contacts WHERE id = ?", (contact_id,)
+        ).fetchone()
+
+        if not contact:
+            raise click.ClickException(f"Contact not found for identifier: {identifier}")
+
+        # Create the note
+        now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+        privacy_tier = "private" if private else "public"
+
+        conn.execute(
+            "INSERT INTO notes (contact_id, note_ts, author, body, privacy_tier) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (contact_id, now, author, text, privacy_tier)
+        )
+
+        # Update notes_count on contact
+        conn.execute(
+            "UPDATE contacts SET notes_count = notes_count + 1, last_updated = ? WHERE id = ?",
+            (now, contact_id)
+        )
+
+        conn.commit()
+
+        privacy_label = " [private]" if private else ""
+        click.echo(f"✓ Note added to {contact['canonical_label']}{privacy_label}")
+
+    except click.ClickException:
+        raise
+    except Exception as e:
+        conn.rollback()
+        raise click.ClickException(str(e))
+    finally:
+        conn.close()

--- a/pf_scout/commands/prospect.py
+++ b/pf_scout/commands/prospect.py
@@ -9,199 +9,46 @@ import requests
 import yaml
 
 from ..db import get_connection
+from ..scoring import (
+    DEFAULT_DIMENSIONS,
+    QUANT_KEYWORDS,
+    TECH_KEYWORDS,
+    evidence_sentence,
+    get_text_blob,
+    infer_role,
+    score_contact,
+    score_engagement_consistency,
+    score_forecasting,
+    score_operational_reliability,
+    score_technical_depth,
+)
 
 
-# ---------------------------------------------------------------------------
-# Default scoring dimensions (used when no rubric YAML provided)
-# ---------------------------------------------------------------------------
-
-TECH_KEYWORDS = [
-    "infrastructure", "devops", "backend", "engineering", "smart contract",
-    "blockchain", "solidity", "rust", "python", "go", "typescript",
-    "kubernetes", "docker", "cloud", "aws", "api", "protocol", "security",
-    "cryptography", "zk", "evm", "validator", "rpc",
+# Re-export for backward compatibility with existing imports (e.g., tests)
+__all__ = [
+    "DEFAULT_DIMENSIONS",
+    "TECH_KEYWORDS",
+    "QUANT_KEYWORDS",
+    "score_technical_depth",
+    "score_forecasting",
+    "score_operational_reliability",
+    "score_engagement_consistency",
+    "score_row",
+    "generate_document",
 ]
-
-QUANT_KEYWORDS = [
-    "quant", "quantitative", "machine learning", "ml", "statistics",
-    "trading", "signal", "forecasting", "data science", "analytics",
-    "on-chain", "onchain", "backtesting", "risk management", "portfolio",
-    "financial modeling", "time series", "alpha", "macro", "research",
-    "modeling", "prediction", "probability",
-]
-
-DEFAULT_DIMENSIONS = [
-    {"key": "technical_depth", "label": "Technical Depth", "weight": 1},
-    {"key": "forecasting", "label": "Forecasting / Quantitative Potential", "weight": 1},
-    {"key": "operational_reliability", "label": "Operational Reliability", "weight": 1},
-    {"key": "engagement_consistency", "label": "Engagement Consistency", "weight": 1},
-]
-
-
-def _text_blob(row: dict) -> str:
-    """Concatenate all text fields from a leaderboard row for keyword search."""
-    parts = []
-    if row.get("summary"):
-        parts.append(str(row["summary"]))
-    for cap in row.get("capabilities") or []:
-        if isinstance(cap, dict):
-            parts.append(" ".join(str(v) for v in cap.values()))
-        else:
-            parts.append(str(cap))
-    for ek in row.get("expert_knowledge") or []:
-        if isinstance(ek, dict):
-            parts.append(" ".join(str(v) for v in ek.values()))
-        else:
-            parts.append(str(ek))
-    return " ".join(parts).lower()
-
-
-def _count_keyword_hits(text: str, keywords: list[str]) -> int:
-    """Count how many distinct keywords appear in text."""
-    return sum(1 for kw in keywords if kw in text)
-
-
-def _hits_to_base(hits: int) -> int:
-    if hits == 0:
-        return 1
-    if hits == 1:
-        return 2
-    if hits == 2:
-        return 3
-    if hits <= 4:
-        return 4
-    return 5
-
-
-def score_technical_depth(row: dict) -> int:
-    text = _text_blob(row)
-    base = _hits_to_base(_count_keyword_hits(text, TECH_KEYWORDS))
-    if (row.get("sybil_score") or 0) >= 85:
-        base += 1
-    return min(base, 5)
-
-
-def score_forecasting(row: dict) -> int:
-    text = _text_blob(row)
-    base = _hits_to_base(_count_keyword_hits(text, QUANT_KEYWORDS))
-    if (row.get("alignment_score") or 0) >= 90:
-        base += 1
-    if (row.get("monthly_rewards") or 0) > 500000:
-        base += 1
-    return min(base, 5)
-
-
-def score_operational_reliability(row: dict) -> int:
-    lsm = row.get("leaderboard_score_month") or 0
-    if lsm < 15:
-        base = 1
-    elif lsm < 40:
-        base = 2
-    elif lsm < 60:
-        base = 3
-    elif lsm < 80:
-        base = 4
-    else:
-        base = 5
-    if (row.get("monthly_tasks") or 0) >= 30:
-        base += 1
-    monthly = row.get("monthly_rewards") or 0
-    weekly = row.get("weekly_rewards") or 0
-    if monthly > 0:
-        ratio = weekly / monthly
-        if 0.2 <= ratio <= 0.35:
-            base += 1
-    return min(base, 5)
-
-
-def score_engagement_consistency(row: dict) -> int:
-    weekly = row.get("weekly_rewards") or 0
-    if weekly <= 0:
-        base = 1
-    elif weekly <= 50000:
-        base = 2
-    elif weekly <= 150000:
-        base = 3
-    elif weekly <= 300000:
-        base = 4
-    else:
-        base = 5
-    if (row.get("leaderboard_score_week") or 0) > 50:
-        base += 1
-    return min(base, 5)
-
-
-SCORERS = {
-    "technical_depth": score_technical_depth,
-    "forecasting": score_forecasting,
-    "operational_reliability": score_operational_reliability,
-    "engagement_consistency": score_engagement_consistency,
-}
 
 
 def score_row(row: dict, dimensions: list[dict]) -> dict:
-    """Score a single leaderboard row against the given dimensions."""
-    scores = {}
-    for dim in dimensions:
-        key = dim["key"]
-        scorer = SCORERS.get(key)
-        scores[key] = scorer(row) if scorer else 1
-    composite = sum(scores.values())
-    max_possible = len(dimensions) * 5
-    pct = composite / max_possible if max_possible else 0
-    if pct >= 0.8:
-        tier = "🔴 Top Tier"
-    elif pct >= 0.6:
-        tier = "🟡 Mid Tier"
-    else:
-        tier = "⚪ Speculative"
-    return {
-        "scores": scores,
-        "composite": composite,
-        "max": max_possible,
-        "pct": pct,
-        "tier": tier,
-    }
-
-
-def _evidence_sentence(row: dict, dim_key: str) -> str:
-    """Generate a brief evidence sentence for a dimension score."""
-    text = _text_blob(row)
-    if dim_key == "technical_depth":
-        hits = [kw for kw in TECH_KEYWORDS if kw in text]
-        if hits:
-            return f"Keywords matched: {', '.join(hits[:5])}."
-        return "No technical keywords found in profile."
-    if dim_key == "forecasting":
-        hits = [kw for kw in QUANT_KEYWORDS if kw in text]
-        if hits:
-            return f"Keywords matched: {', '.join(hits[:5])}."
-        return "No quantitative keywords found in profile."
-    if dim_key == "operational_reliability":
-        lsm = row.get("leaderboard_score_month") or 0
-        mt = row.get("monthly_tasks") or 0
-        return f"Leaderboard score (month): {lsm}, monthly tasks: {mt}."
-    if dim_key == "engagement_consistency":
-        wr = row.get("weekly_rewards") or 0
-        lsw = row.get("leaderboard_score_week") or 0
-        return f"Weekly rewards: {wr:,.0f}, leaderboard score (week): {lsw}."
-    return "No evidence available."
-
-
-def _infer_role(row: dict) -> str:
-    text = _text_blob(row)
-    if any(kw in text for kw in ["trading", "quant", "alpha", "signal"]):
-        return "Signal / Quant"
-    if any(kw in text for kw in ["infrastructure", "devops", "kubernetes", "docker"]):
-        return "Infrastructure"
-    if any(kw in text for kw in ["smart contract", "solidity", "evm", "blockchain"]):
-        return "Protocol Engineer"
-    if any(kw in text for kw in ["research", "analytics", "data science"]):
-        return "Researcher"
-    return "Contributor"
+    """Score a single leaderboard row against the given dimensions.
+    
+    This is a thin wrapper around scoring.score_contact for backward
+    compatibility with existing code and tests.
+    """
+    return score_contact(row, dimensions)
 
 
 def _fetch_leaderboard(jwt: str, base_url: str) -> list[dict]:
+    """Fetch live leaderboard data from the Post Fiat API."""
     resp = requests.get(
         f"{base_url}/api/leaderboard",
         headers={
@@ -215,6 +62,7 @@ def _fetch_leaderboard(jwt: str, base_url: str) -> list[dict]:
 
 
 def _load_from_db(db_path: str) -> list[dict]:
+    """Load leaderboard data from local database snapshots."""
     conn = get_connection(db_path)
     rows = conn.execute(
         "SELECT payload FROM signals WHERE signal_type = 'postfiat/leaderboard' "
@@ -234,6 +82,7 @@ def _load_from_db(db_path: str) -> list[dict]:
 
 
 def _load_rubric(rubric_path: str) -> tuple[str, list[dict]]:
+    """Load and parse a rubric YAML file."""
     with open(rubric_path) as f:
         rubric = yaml.safe_load(f)
     name = rubric.get("name", Path(rubric_path).stem)
@@ -255,7 +104,18 @@ def generate_document(
     title: str,
     min_composite: int,
 ) -> str:
-    """Score all rows and generate the markdown pipeline document."""
+    """Score all rows and generate the markdown pipeline document.
+    
+    Args:
+        rows: List of leaderboard row dictionaries.
+        dimensions: List of dimension dicts from rubric.
+        rubric_name: Name of the rubric for display.
+        title: Document title prefix.
+        min_composite: Minimum composite score to include.
+    
+    Returns:
+        Markdown document string.
+    """
     today = datetime.utcnow().strftime("%Y-%m-%d")
     scored = []
     for row in rows:
@@ -264,7 +124,7 @@ def generate_document(
             continue
         label = row.get("summary") or row.get("wallet_address", "unknown")
         wallet = row.get("wallet_address", "")
-        role = _infer_role(row)
+        role = infer_role(row)
         scored.append({
             "label": label,
             "wallet": wallet,
@@ -342,7 +202,7 @@ def generate_document(
 
         for d in dimensions:
             score_val = s["scores"].get(d["key"], "-")
-            evidence = _evidence_sentence(s["row"], d["key"])
+            evidence = evidence_sentence(s["row"], d["key"])
             lines.append(f"**{d['label']} ({score_val}/5):** {evidence}\n")
 
         # Assessment

--- a/pf_scout/commands/prospect.py
+++ b/pf_scout/commands/prospect.py
@@ -14,7 +14,6 @@ from ..scoring import (
     QUANT_KEYWORDS,
     TECH_KEYWORDS,
     evidence_sentence,
-    get_text_blob,
     infer_role,
     score_contact,
     score_engagement_consistency,
@@ -40,7 +39,7 @@ __all__ = [
 
 def score_row(row: dict, dimensions: list[dict]) -> dict:
     """Score a single leaderboard row against the given dimensions.
-    
+
     This is a thin wrapper around scoring.score_contact for backward
     compatibility with existing code and tests.
     """
@@ -105,14 +104,14 @@ def generate_document(
     min_composite: int,
 ) -> str:
     """Score all rows and generate the markdown pipeline document.
-    
+
     Args:
         rows: List of leaderboard row dictionaries.
         dimensions: List of dimension dicts from rubric.
         rubric_name: Name of the rubric for display.
         title: Document title prefix.
         min_composite: Minimum composite score to include.
-    
+
     Returns:
         Markdown document string.
     """

--- a/pf_scout/commands/seed.py
+++ b/pf_scout/commands/seed.py
@@ -41,69 +41,70 @@ def seed_github(ctx, org, token):
         identifiers = collector.discover(org, token)
         click.echo(f"Found {len(identifiers)} contributors")
 
-        for platform, ident_value in identifiers:
-            now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+        with click.progressbar(identifiers, label="Seeding contacts", show_pos=True) as bar:
+            for platform, ident_value in bar:
+                now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
-            # Check if identifier already exists
-            existing = conn.execute(
-                "SELECT id, contact_id FROM identifiers WHERE platform = ? AND identifier_value = ?",
-                (platform, ident_value)
-            ).fetchone()
+                # Check if identifier already exists
+                existing = conn.execute(
+                    "SELECT id, contact_id FROM identifiers WHERE platform = ? AND identifier_value = ?",
+                    (platform, ident_value)
+                ).fetchone()
 
-            if existing:
-                contact_id = existing["contact_id"]
-                ident_id = existing["id"]
-            else:
-                # Create new contact + identifier
-                contact_id = str(uuid.uuid4())
-                ident_id = str(uuid.uuid4())
+                if existing:
+                    contact_id = existing["contact_id"]
+                    ident_id = existing["id"]
+                else:
+                    # Create new contact + identifier
+                    contact_id = str(uuid.uuid4())
+                    ident_id = str(uuid.uuid4())
 
+                    conn.execute(
+                        "INSERT INTO contacts (id, canonical_label, first_seen, last_updated) "
+                        "VALUES (?, ?, ?, ?)",
+                        (contact_id, ident_value, now, now)
+                    )
+                    conn.execute(
+                        "INSERT INTO identifiers "
+                        "(id, contact_id, platform, identifier_value, is_primary, "
+                        "first_seen, last_seen, link_confidence, link_source) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (ident_id, contact_id, platform, ident_value, 1, now, now, 1.0, "seed")
+                    )
+                    contacts_created += 1
+
+                # Collect signals
+                collected = collector.collect(ident_value, contact_id, token)
+
+                for sig in collected:
+                    fingerprint = compute_event_fingerprint(
+                        contact_id, sig.source, sig.signal_type,
+                        sig.source_event_id, sig.payload
+                    )
+
+                    payload_json = json.dumps(sig.payload, sort_keys=True, ensure_ascii=True)
+
+                    cursor = conn.execute(
+                        "INSERT OR IGNORE INTO signals "
+                        "(contact_id, identifier_id, collected_at, signal_ts, source, signal_type, "
+                        "source_event_id, event_fingerprint, payload, evidence_note) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (contact_id, ident_id, now, sig.signal_ts, sig.source, sig.signal_type,
+                         sig.source_event_id, fingerprint, payload_json, sig.evidence_note)
+                    )
+                    if cursor.rowcount > 0:
+                        signals_inserted += 1
+
+                # Update last_seen on identifier
                 conn.execute(
-                    "INSERT INTO contacts (id, canonical_label, first_seen, last_updated) "
-                    "VALUES (?, ?, ?, ?)",
-                    (contact_id, ident_value, now, now)
+                    "UPDATE identifiers SET last_seen = ? WHERE id = ?",
+                    (now, ident_id)
                 )
+                # Update last_updated on contact
                 conn.execute(
-                    "INSERT INTO identifiers "
-                    "(id, contact_id, platform, identifier_value, is_primary, "
-                    "first_seen, last_seen, link_confidence, link_source) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (ident_id, contact_id, platform, ident_value, 1, now, now, 1.0, "seed")
+                    "UPDATE contacts SET last_updated = ? WHERE id = ?",
+                    (now, contact_id)
                 )
-                contacts_created += 1
-
-            # Collect signals
-            collected = collector.collect(ident_value, contact_id, token)
-
-            for sig in collected:
-                fingerprint = compute_event_fingerprint(
-                    contact_id, sig.source, sig.signal_type,
-                    sig.source_event_id, sig.payload
-                )
-
-                payload_json = json.dumps(sig.payload, sort_keys=True, ensure_ascii=True)
-
-                cursor = conn.execute(
-                    "INSERT OR IGNORE INTO signals "
-                    "(contact_id, identifier_id, collected_at, signal_ts, source, signal_type, "
-                    "source_event_id, event_fingerprint, payload, evidence_note) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (contact_id, ident_id, now, sig.signal_ts, sig.source, sig.signal_type,
-                     sig.source_event_id, fingerprint, payload_json, sig.evidence_note)
-                )
-                if cursor.rowcount > 0:
-                    signals_inserted += 1
-
-            # Update last_seen on identifier
-            conn.execute(
-                "UPDATE identifiers SET last_seen = ? WHERE id = ?",
-                (now, ident_id)
-            )
-            # Update last_updated on contact
-            conn.execute(
-                "UPDATE contacts SET last_updated = ? WHERE id = ?",
-                (now, contact_id)
-            )
 
         conn.commit()
         click.echo(f"Seeded {contacts_created} contacts, {signals_inserted} signals from github:{org}")

--- a/pf_scout/commands/show.py
+++ b/pf_scout/commands/show.py
@@ -8,7 +8,7 @@ import click
 from ..db import get_connection
 
 
-def render_text_card(contact, identifiers, signals, notes, show_history=False, show_signals=False):
+def render_text_card(contact, identifiers, signals, notes, show_history=False, show_signals=False, show_notes=False):
     """Render a terminal-friendly contact card with box-drawing characters."""
     label = contact["canonical_label"]
     cid = contact["id"]
@@ -56,13 +56,17 @@ def render_text_card(contact, identifiers, signals, notes, show_history=False, s
         if len(signals) > 20:
             lines.append(f"│ {'  ... and ' + str(len(signals) - 20) + ' more':<{inner - 1}}│")
 
-    # Notes / history section
-    if show_history and notes:
+    # Notes section (show_notes or show_history for backward compat)
+    if (show_notes or show_history) and notes:
         lines.append(f"├{'─' * inner}┤")
         lines.append(f"│ {'Notes (' + str(len(notes)) + ')':<{inner - 1}}│")
         for note in notes[:10]:
-            note_str = f"  [{note['note_ts']}] {note['body'][:30]}"
+            privacy = " 🔒" if note["privacy_tier"] == "private" else ""
+            note_preview = note["body"][:28] if len(note["body"]) > 28 else note["body"]
+            note_str = f"  [{note['note_ts'][:10]}]{privacy} {note_preview}"
             lines.append(f"│ {note_str:<{inner - 1}}│")
+        if len(notes) > 10:
+            lines.append(f"│ {'  ... and ' + str(len(notes) - 10) + ' more':<{inner - 1}}│")
 
     lines.append(f"└{'─' * inner}┘")
     return "\n".join(lines)
@@ -187,10 +191,11 @@ def _render_context_section(conn, contact_id: str, scout_dir: Path, my_keywords:
 @click.argument("identifier")
 @click.option("--format", "output_format", type=click.Choice(["text", "json", "md"]),
               default="text", help="Output format")
-@click.option("--history", is_flag=True, help="Show notes/history")
+@click.option("--history", is_flag=True, help="Show notes/history (alias for --notes)")
+@click.option("--notes", "show_notes", is_flag=True, help="Show notes")
 @click.option("--signals", "show_signals", is_flag=True, help="Show signals")
 @click.pass_context
-def show_command(ctx, identifier, output_format, history, show_signals):
+def show_command(ctx, identifier, output_format, history, show_notes, show_signals):
     """Show a contact card by identifier (platform:value)."""
     db_path = ctx.obj["db_path"]
     conn = get_connection(db_path)
@@ -245,7 +250,7 @@ def show_command(ctx, identifier, output_format, history, show_signals):
         else:
             click.echo(render_text_card(
                 contact, identifiers_rows, signals_rows, notes_rows,
-                show_history=history, show_signals=show_signals
+                show_history=history, show_signals=show_signals, show_notes=show_notes
             ))
 
         # PF Context section (appended to all formats)

--- a/pf_scout/commands/update.py
+++ b/pf_scout/commands/update.py
@@ -260,37 +260,34 @@ def update_command(ctx, identifier, update_all, since, rubric_path, batch, dry_r
                 params.append(cutoff)
 
             contacts = conn.execute(query, params).fetchall()
-            click.echo(f"Updating {len(contacts)} contacts...")
 
-            for contact in contacts:
-                contact_id = contact["id"]
-                label = contact["canonical_label"]
-                click.echo(f"\n--- {label} ---")
+            if dry_run:
+                click.echo(f"Updating {len(contacts)} contacts (dry-run)...")
+                for contact in contacts:
+                    click.echo(f"  [dry-run] Would re-collect signals for {contact['canonical_label']}")
+            else:
+                with click.progressbar(contacts, label=f"Updating {len(contacts)} contacts", show_pos=True) as bar:
+                    for contact in bar:
+                        contact_id = contact["id"]
+                        label = contact["canonical_label"]
 
-                try:
-                    if dry_run:
-                        click.echo(f"  [dry-run] Would re-collect signals for {label}")
-                        continue
+                        try:
+                            new_count, existing_count, errors = collect_signals_for_contact(
+                                conn, contact_id, token
+                            )
 
-                    new_count, existing_count, errors = collect_signals_for_contact(
-                        conn, contact_id, token
-                    )
-                    click.echo(f"  {new_count} new signals found / {existing_count} already known")
+                            if errors:
+                                for err in errors:
+                                    failures.append(f"{label}: {err}")
 
-                    if errors:
-                        for err in errors:
-                            click.echo(f"  ⚠ {err}", err=True)
-                            failures.append(f"{label}: {err}")
+                            if rubric:
+                                run_scoring(conn, contact_id, rubric, batch=batch)
 
-                    if rubric:
-                        run_scoring(conn, contact_id, rubric, batch=batch)
+                        except Exception as e:
+                            failures.append(f"{label}: {e}")
+                            continue
 
-                except Exception as e:
-                    failures.append(f"{label}: {e}")
-                    click.echo(f"  ✗ Error: {e}", err=True)
-                    continue
-
-            conn.commit()
+                conn.commit()
 
             if failures:
                 click.echo(f"\n⚠ {len(failures)} failures:")

--- a/pf_scout/rubric.py
+++ b/pf_scout/rubric.py
@@ -1,0 +1,281 @@
+"""Rubric validation and loading for pf-scout.
+
+This module provides functions to validate and load rubric YAML files.
+A rubric defines dimensions, weights, and tier thresholds for scoring.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Required rubric fields
+# ---------------------------------------------------------------------------
+
+REQUIRED_TOP_LEVEL = ["name", "dimensions"]
+REQUIRED_DIMENSION_FIELDS = ["key"]
+OPTIONAL_DIMENSION_FIELDS = ["label", "weight", "guide", "keywords", "description"]
+OPTIONAL_TOP_LEVEL = ["version", "description", "tiers"]
+
+
+# ---------------------------------------------------------------------------
+# Validation functions
+# ---------------------------------------------------------------------------
+
+class RubricValidationError(Exception):
+    """Raised when rubric validation fails."""
+    
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__(f"Rubric validation failed: {'; '.join(errors)}")
+
+
+def validate_rubric(path: str | Path) -> list[str]:
+    """Validate a rubric YAML file.
+    
+    Checks for required fields, valid structure, and valid types.
+    
+    Args:
+        path: Path to the rubric YAML file.
+    
+    Returns:
+        List of validation errors (empty if valid).
+    """
+    errors = []
+    path = Path(path)
+    
+    # Check file exists
+    if not path.exists():
+        return [f"Rubric file not found: {path}"]
+    
+    if not path.is_file():
+        return [f"Path is not a file: {path}"]
+    
+    # Parse YAML
+    try:
+        with open(path) as f:
+            rubric = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        return [f"Invalid YAML: {e}"]
+    
+    if not isinstance(rubric, dict):
+        return ["Rubric must be a YAML mapping (dictionary)"]
+    
+    # Check required top-level fields
+    for field in REQUIRED_TOP_LEVEL:
+        if field not in rubric:
+            errors.append(f"Missing required field: {field}")
+    
+    # Validate name
+    if "name" in rubric:
+        if not isinstance(rubric["name"], str):
+            errors.append("'name' must be a string")
+        elif not rubric["name"].strip():
+            errors.append("'name' cannot be empty")
+    
+    # Validate version if present
+    if "version" in rubric:
+        v = rubric["version"]
+        if not isinstance(v, (str, int, float)):
+            errors.append("'version' must be a string or number")
+    
+    # Validate dimensions
+    if "dimensions" in rubric:
+        dims = rubric["dimensions"]
+        if not isinstance(dims, list):
+            errors.append("'dimensions' must be a list")
+        elif len(dims) == 0:
+            errors.append("'dimensions' cannot be empty")
+        else:
+            seen_keys = set()
+            for i, dim in enumerate(dims):
+                dim_errors = _validate_dimension(dim, i, seen_keys)
+                errors.extend(dim_errors)
+    
+    # Validate tiers if present
+    if "tiers" in rubric:
+        tiers = rubric["tiers"]
+        if not isinstance(tiers, list):
+            errors.append("'tiers' must be a list")
+        else:
+            for i, tier in enumerate(tiers):
+                tier_errors = _validate_tier(tier, i)
+                errors.extend(tier_errors)
+    
+    return errors
+
+
+def _validate_dimension(dim: Any, index: int, seen_keys: set) -> list[str]:
+    """Validate a single dimension entry.
+    
+    Args:
+        dim: The dimension dict to validate.
+        index: Index in the dimensions list (for error messages).
+        seen_keys: Set of already-seen dimension keys.
+    
+    Returns:
+        List of validation errors.
+    """
+    errors = []
+    prefix = f"dimensions[{index}]"
+    
+    if not isinstance(dim, dict):
+        return [f"{prefix}: must be a mapping"]
+    
+    # Check required dimension fields
+    for field in REQUIRED_DIMENSION_FIELDS:
+        if field not in dim:
+            errors.append(f"{prefix}: missing required field '{field}'")
+    
+    # Validate key
+    if "key" in dim:
+        key = dim["key"]
+        if not isinstance(key, str):
+            errors.append(f"{prefix}: 'key' must be a string")
+        elif not key.strip():
+            errors.append(f"{prefix}: 'key' cannot be empty")
+        elif key in seen_keys:
+            errors.append(f"{prefix}: duplicate key '{key}'")
+        else:
+            seen_keys.add(key)
+    
+    # Validate weight
+    if "weight" in dim:
+        weight = dim["weight"]
+        if not isinstance(weight, (int, float)):
+            errors.append(f"{prefix}: 'weight' must be a number")
+        elif weight <= 0:
+            errors.append(f"{prefix}: 'weight' must be positive")
+    
+    # Validate label
+    if "label" in dim and not isinstance(dim["label"], str):
+        errors.append(f"{prefix}: 'label' must be a string")
+    
+    # Validate keywords
+    if "keywords" in dim:
+        kw = dim["keywords"]
+        if not isinstance(kw, list):
+            errors.append(f"{prefix}: 'keywords' must be a list")
+        elif not all(isinstance(k, str) for k in kw):
+            errors.append(f"{prefix}: all keywords must be strings")
+    
+    return errors
+
+
+def _validate_tier(tier: Any, index: int) -> list[str]:
+    """Validate a single tier entry.
+    
+    Args:
+        tier: The tier dict to validate.
+        index: Index in the tiers list (for error messages).
+    
+    Returns:
+        List of validation errors.
+    """
+    errors = []
+    prefix = f"tiers[{index}]"
+    
+    if not isinstance(tier, dict):
+        return [f"{prefix}: must be a mapping"]
+    
+    # Check required tier fields
+    if "name" not in tier:
+        errors.append(f"{prefix}: missing required field 'name'")
+    elif not isinstance(tier["name"], str):
+        errors.append(f"{prefix}: 'name' must be a string")
+    
+    # Require either min_pct or min_score
+    has_threshold = "min_pct" in tier or "min_score" in tier
+    if not has_threshold:
+        errors.append(f"{prefix}: missing 'min_pct' or 'min_score'")
+    
+    if "min_pct" in tier:
+        if not isinstance(tier["min_pct"], (int, float)):
+            errors.append(f"{prefix}: 'min_pct' must be a number")
+        elif not (0 <= tier["min_pct"] <= 1):
+            errors.append(f"{prefix}: 'min_pct' must be between 0 and 1")
+    
+    if "min_score" in tier:
+        if not isinstance(tier["min_score"], (int, float)):
+            errors.append(f"{prefix}: 'min_score' must be a number")
+        elif tier["min_score"] < 0:
+            errors.append(f"{prefix}: 'min_score' must be non-negative")
+    
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Loading functions
+# ---------------------------------------------------------------------------
+
+def load_rubric(path: str | Path) -> dict:
+    """Load and validate a rubric YAML file.
+    
+    Args:
+        path: Path to the rubric YAML file.
+    
+    Returns:
+        Parsed rubric dictionary with normalized structure.
+    
+    Raises:
+        RubricValidationError: If validation fails.
+        FileNotFoundError: If file doesn't exist.
+    """
+    path = Path(path)
+    
+    # Validate first
+    errors = validate_rubric(path)
+    if errors:
+        raise RubricValidationError(errors)
+    
+    # Load and normalize
+    with open(path) as f:
+        rubric = yaml.safe_load(f)
+    
+    # Normalize dimensions
+    normalized_dims = []
+    for dim in rubric.get("dimensions", []):
+        normalized_dims.append({
+            "key": dim["key"],
+            "label": dim.get("label", dim["key"]),
+            "weight": dim.get("weight", 1),
+            "description": dim.get("guide", dim.get("description", "")),
+            "keywords": dim.get("keywords"),
+        })
+    
+    # Normalize tiers (use defaults if not provided)
+    tiers = rubric.get("tiers")
+    if not tiers:
+        tiers = [
+            {"name": "🔴 Top Tier", "min_pct": 0.80, "description": "Strong prospect"},
+            {"name": "🟡 Mid Tier", "min_pct": 0.60, "description": "Promising"},
+            {"name": "⚪ Speculative", "min_pct": 0.0, "description": "Early signal"},
+        ]
+    
+    return {
+        "name": rubric.get("name", path.stem),
+        "version": str(rubric.get("version", "1.0")),
+        "description": rubric.get("description", ""),
+        "dimensions": normalized_dims,
+        "tiers": tiers,
+    }
+
+
+def get_rubric_name(path: str | Path) -> str:
+    """Get the name from a rubric file without full validation.
+    
+    Args:
+        path: Path to the rubric YAML file.
+    
+    Returns:
+        Rubric name or filename stem if name not found.
+    """
+    path = Path(path)
+    try:
+        with open(path) as f:
+            rubric = yaml.safe_load(f)
+        return rubric.get("name", path.stem)
+    except Exception:
+        return path.stem

--- a/pf_scout/rubric.py
+++ b/pf_scout/rubric.py
@@ -26,7 +26,7 @@ OPTIONAL_TOP_LEVEL = ["version", "description", "tiers"]
 
 class RubricValidationError(Exception):
     """Raised when rubric validation fails."""
-    
+
     def __init__(self, errors: list[str]):
         self.errors = errors
         super().__init__(f"Rubric validation failed: {'; '.join(errors)}")
@@ -34,53 +34,53 @@ class RubricValidationError(Exception):
 
 def validate_rubric(path: str | Path) -> list[str]:
     """Validate a rubric YAML file.
-    
+
     Checks for required fields, valid structure, and valid types.
-    
+
     Args:
         path: Path to the rubric YAML file.
-    
+
     Returns:
         List of validation errors (empty if valid).
     """
     errors = []
     path = Path(path)
-    
+
     # Check file exists
     if not path.exists():
         return [f"Rubric file not found: {path}"]
-    
+
     if not path.is_file():
         return [f"Path is not a file: {path}"]
-    
+
     # Parse YAML
     try:
         with open(path) as f:
             rubric = yaml.safe_load(f)
     except yaml.YAMLError as e:
         return [f"Invalid YAML: {e}"]
-    
+
     if not isinstance(rubric, dict):
         return ["Rubric must be a YAML mapping (dictionary)"]
-    
+
     # Check required top-level fields
     for field in REQUIRED_TOP_LEVEL:
         if field not in rubric:
             errors.append(f"Missing required field: {field}")
-    
+
     # Validate name
     if "name" in rubric:
         if not isinstance(rubric["name"], str):
             errors.append("'name' must be a string")
         elif not rubric["name"].strip():
             errors.append("'name' cannot be empty")
-    
+
     # Validate version if present
     if "version" in rubric:
         v = rubric["version"]
         if not isinstance(v, (str, int, float)):
             errors.append("'version' must be a string or number")
-    
+
     # Validate dimensions
     if "dimensions" in rubric:
         dims = rubric["dimensions"]
@@ -93,7 +93,7 @@ def validate_rubric(path: str | Path) -> list[str]:
             for i, dim in enumerate(dims):
                 dim_errors = _validate_dimension(dim, i, seen_keys)
                 errors.extend(dim_errors)
-    
+
     # Validate tiers if present
     if "tiers" in rubric:
         tiers = rubric["tiers"]
@@ -103,32 +103,32 @@ def validate_rubric(path: str | Path) -> list[str]:
             for i, tier in enumerate(tiers):
                 tier_errors = _validate_tier(tier, i)
                 errors.extend(tier_errors)
-    
+
     return errors
 
 
 def _validate_dimension(dim: Any, index: int, seen_keys: set) -> list[str]:
     """Validate a single dimension entry.
-    
+
     Args:
         dim: The dimension dict to validate.
         index: Index in the dimensions list (for error messages).
         seen_keys: Set of already-seen dimension keys.
-    
+
     Returns:
         List of validation errors.
     """
     errors = []
     prefix = f"dimensions[{index}]"
-    
+
     if not isinstance(dim, dict):
         return [f"{prefix}: must be a mapping"]
-    
+
     # Check required dimension fields
     for field in REQUIRED_DIMENSION_FIELDS:
         if field not in dim:
             errors.append(f"{prefix}: missing required field '{field}'")
-    
+
     # Validate key
     if "key" in dim:
         key = dim["key"]
@@ -140,7 +140,7 @@ def _validate_dimension(dim: Any, index: int, seen_keys: set) -> list[str]:
             errors.append(f"{prefix}: duplicate key '{key}'")
         else:
             seen_keys.add(key)
-    
+
     # Validate weight
     if "weight" in dim:
         weight = dim["weight"]
@@ -148,11 +148,11 @@ def _validate_dimension(dim: Any, index: int, seen_keys: set) -> list[str]:
             errors.append(f"{prefix}: 'weight' must be a number")
         elif weight <= 0:
             errors.append(f"{prefix}: 'weight' must be positive")
-    
+
     # Validate label
     if "label" in dim and not isinstance(dim["label"], str):
         errors.append(f"{prefix}: 'label' must be a string")
-    
+
     # Validate keywords
     if "keywords" in dim:
         kw = dim["keywords"]
@@ -160,49 +160,49 @@ def _validate_dimension(dim: Any, index: int, seen_keys: set) -> list[str]:
             errors.append(f"{prefix}: 'keywords' must be a list")
         elif not all(isinstance(k, str) for k in kw):
             errors.append(f"{prefix}: all keywords must be strings")
-    
+
     return errors
 
 
 def _validate_tier(tier: Any, index: int) -> list[str]:
     """Validate a single tier entry.
-    
+
     Args:
         tier: The tier dict to validate.
         index: Index in the tiers list (for error messages).
-    
+
     Returns:
         List of validation errors.
     """
     errors = []
     prefix = f"tiers[{index}]"
-    
+
     if not isinstance(tier, dict):
         return [f"{prefix}: must be a mapping"]
-    
+
     # Check required tier fields
     if "name" not in tier:
         errors.append(f"{prefix}: missing required field 'name'")
     elif not isinstance(tier["name"], str):
         errors.append(f"{prefix}: 'name' must be a string")
-    
+
     # Require either min_pct or min_score
     has_threshold = "min_pct" in tier or "min_score" in tier
     if not has_threshold:
         errors.append(f"{prefix}: missing 'min_pct' or 'min_score'")
-    
+
     if "min_pct" in tier:
         if not isinstance(tier["min_pct"], (int, float)):
             errors.append(f"{prefix}: 'min_pct' must be a number")
         elif not (0 <= tier["min_pct"] <= 1):
             errors.append(f"{prefix}: 'min_pct' must be between 0 and 1")
-    
+
     if "min_score" in tier:
         if not isinstance(tier["min_score"], (int, float)):
             errors.append(f"{prefix}: 'min_score' must be a number")
         elif tier["min_score"] < 0:
             errors.append(f"{prefix}: 'min_score' must be non-negative")
-    
+
     return errors
 
 
@@ -212,28 +212,28 @@ def _validate_tier(tier: Any, index: int) -> list[str]:
 
 def load_rubric(path: str | Path) -> dict:
     """Load and validate a rubric YAML file.
-    
+
     Args:
         path: Path to the rubric YAML file.
-    
+
     Returns:
         Parsed rubric dictionary with normalized structure.
-    
+
     Raises:
         RubricValidationError: If validation fails.
         FileNotFoundError: If file doesn't exist.
     """
     path = Path(path)
-    
+
     # Validate first
     errors = validate_rubric(path)
     if errors:
         raise RubricValidationError(errors)
-    
+
     # Load and normalize
     with open(path) as f:
         rubric = yaml.safe_load(f)
-    
+
     # Normalize dimensions
     normalized_dims = []
     for dim in rubric.get("dimensions", []):
@@ -244,7 +244,7 @@ def load_rubric(path: str | Path) -> dict:
             "description": dim.get("guide", dim.get("description", "")),
             "keywords": dim.get("keywords"),
         })
-    
+
     # Normalize tiers (use defaults if not provided)
     tiers = rubric.get("tiers")
     if not tiers:
@@ -253,7 +253,7 @@ def load_rubric(path: str | Path) -> dict:
             {"name": "🟡 Mid Tier", "min_pct": 0.60, "description": "Promising"},
             {"name": "⚪ Speculative", "min_pct": 0.0, "description": "Early signal"},
         ]
-    
+
     return {
         "name": rubric.get("name", path.stem),
         "version": str(rubric.get("version", "1.0")),
@@ -265,10 +265,10 @@ def load_rubric(path: str | Path) -> dict:
 
 def get_rubric_name(path: str | Path) -> str:
     """Get the name from a rubric file without full validation.
-    
+
     Args:
         path: Path to the rubric YAML file.
-    
+
     Returns:
         Rubric name or filename stem if name not found.
     """

--- a/pf_scout/scoring.py
+++ b/pf_scout/scoring.py
@@ -1,0 +1,352 @@
+"""Shared scoring logic for pf-scout.
+
+This module provides reusable scoring functions for evaluating contacts
+against rubric dimensions. Used by prospect, report, and other commands.
+"""
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Default keyword sets for heuristic scoring
+# ---------------------------------------------------------------------------
+
+TECH_KEYWORDS = [
+    "infrastructure", "devops", "backend", "engineering", "smart contract",
+    "blockchain", "solidity", "rust", "python", "go", "typescript",
+    "kubernetes", "docker", "cloud", "aws", "api", "protocol", "security",
+    "cryptography", "zk", "evm", "validator", "rpc",
+]
+
+QUANT_KEYWORDS = [
+    "quant", "quantitative", "machine learning", "ml", "statistics",
+    "trading", "signal", "forecasting", "data science", "analytics",
+    "on-chain", "onchain", "backtesting", "risk management", "portfolio",
+    "financial modeling", "time series", "alpha", "macro", "research",
+    "modeling", "prediction", "probability",
+]
+
+# ---------------------------------------------------------------------------
+# Default dimensions (used when no rubric YAML provided)
+# ---------------------------------------------------------------------------
+
+DEFAULT_DIMENSIONS = [
+    {"key": "technical_depth", "label": "Technical Depth", "weight": 1},
+    {"key": "forecasting", "label": "Forecasting / Quantitative Potential", "weight": 1},
+    {"key": "operational_reliability", "label": "Operational Reliability", "weight": 1},
+    {"key": "engagement_consistency", "label": "Engagement Consistency", "weight": 1},
+]
+
+
+# ---------------------------------------------------------------------------
+# Text extraction and keyword utilities
+# ---------------------------------------------------------------------------
+
+def get_text_blob(row: dict) -> str:
+    """Concatenate all text fields from a leaderboard row for keyword search.
+    
+    Args:
+        row: A leaderboard row dictionary with summary, capabilities, etc.
+    
+    Returns:
+        Lowercased concatenated text for keyword matching.
+    """
+    parts = []
+    if row.get("summary"):
+        parts.append(str(row["summary"]))
+    for cap in row.get("capabilities") or []:
+        if isinstance(cap, dict):
+            parts.append(" ".join(str(v) for v in cap.values()))
+        else:
+            parts.append(str(cap))
+    for ek in row.get("expert_knowledge") or []:
+        if isinstance(ek, dict):
+            parts.append(" ".join(str(v) for v in ek.values()))
+        else:
+            parts.append(str(ek))
+    return " ".join(parts).lower()
+
+
+def apply_keyword_heuristics(text: str, keywords: list[str]) -> int:
+    """Count keyword hits and convert to a 1-5 score.
+    
+    Args:
+        text: The lowercased text to search in.
+        keywords: List of keywords to look for.
+    
+    Returns:
+        Score from 1-5 based on number of keyword matches.
+    """
+    hits = sum(1 for kw in keywords if kw in text)
+    if hits == 0:
+        return 1
+    if hits == 1:
+        return 2
+    if hits == 2:
+        return 3
+    if hits <= 4:
+        return 4
+    return 5
+
+
+def count_keyword_hits(text: str, keywords: list[str]) -> int:
+    """Count how many distinct keywords appear in text.
+    
+    Args:
+        text: The lowercased text to search in.
+        keywords: List of keywords to look for.
+    
+    Returns:
+        Number of keyword matches.
+    """
+    return sum(1 for kw in keywords if kw in text)
+
+
+def get_matching_keywords(text: str, keywords: list[str], limit: int = 5) -> list[str]:
+    """Get list of matching keywords from text.
+    
+    Args:
+        text: The lowercased text to search in.
+        keywords: List of keywords to look for.
+        limit: Maximum number of matches to return.
+    
+    Returns:
+        List of matched keywords (up to limit).
+    """
+    return [kw for kw in keywords if kw in text][:limit]
+
+
+# ---------------------------------------------------------------------------
+# Individual dimension scorers
+# ---------------------------------------------------------------------------
+
+def score_technical_depth(row: dict) -> int:
+    """Score technical depth (1-5) based on tech keywords and sybil score.
+    
+    Args:
+        row: Leaderboard row with capabilities, summary, sybil_score.
+    
+    Returns:
+        Score from 1-5.
+    """
+    text = get_text_blob(row)
+    base = apply_keyword_heuristics(text, TECH_KEYWORDS)
+    if (row.get("sybil_score") or 0) >= 85:
+        base += 1
+    return min(base, 5)
+
+
+def score_forecasting(row: dict) -> int:
+    """Score quantitative/forecasting potential (1-5).
+    
+    Args:
+        row: Leaderboard row with capabilities, alignment_score, monthly_rewards.
+    
+    Returns:
+        Score from 1-5.
+    """
+    text = get_text_blob(row)
+    base = apply_keyword_heuristics(text, QUANT_KEYWORDS)
+    if (row.get("alignment_score") or 0) >= 90:
+        base += 1
+    if (row.get("monthly_rewards") or 0) > 500000:
+        base += 1
+    return min(base, 5)
+
+
+def score_operational_reliability(row: dict) -> int:
+    """Score operational reliability (1-5) based on leaderboard metrics.
+    
+    Args:
+        row: Leaderboard row with leaderboard_score_month, monthly_tasks, rewards.
+    
+    Returns:
+        Score from 1-5.
+    """
+    lsm = row.get("leaderboard_score_month") or 0
+    if lsm < 15:
+        base = 1
+    elif lsm < 40:
+        base = 2
+    elif lsm < 60:
+        base = 3
+    elif lsm < 80:
+        base = 4
+    else:
+        base = 5
+    if (row.get("monthly_tasks") or 0) >= 30:
+        base += 1
+    monthly = row.get("monthly_rewards") or 0
+    weekly = row.get("weekly_rewards") or 0
+    if monthly > 0:
+        ratio = weekly / monthly
+        if 0.2 <= ratio <= 0.35:
+            base += 1
+    return min(base, 5)
+
+
+def score_engagement_consistency(row: dict) -> int:
+    """Score engagement consistency (1-5) based on weekly activity.
+    
+    Args:
+        row: Leaderboard row with weekly_rewards, leaderboard_score_week.
+    
+    Returns:
+        Score from 1-5.
+    """
+    weekly = row.get("weekly_rewards") or 0
+    if weekly <= 0:
+        base = 1
+    elif weekly <= 50000:
+        base = 2
+    elif weekly <= 150000:
+        base = 3
+    elif weekly <= 300000:
+        base = 4
+    else:
+        base = 5
+    if (row.get("leaderboard_score_week") or 0) > 50:
+        base += 1
+    return min(base, 5)
+
+
+# ---------------------------------------------------------------------------
+# Scorer registry
+# ---------------------------------------------------------------------------
+
+SCORERS = {
+    "technical_depth": score_technical_depth,
+    "forecasting": score_forecasting,
+    "operational_reliability": score_operational_reliability,
+    "engagement_consistency": score_engagement_consistency,
+}
+
+
+# ---------------------------------------------------------------------------
+# High-level scoring functions
+# ---------------------------------------------------------------------------
+
+def score_dimension(row: dict, dimension_key: str, keywords: list[str] | None = None) -> int:
+    """Score a single dimension (1-5).
+    
+    If a registered scorer exists for the dimension_key, use it.
+    Otherwise, fall back to keyword heuristics if keywords are provided.
+    
+    Args:
+        row: The data row to score.
+        dimension_key: The dimension identifier (e.g., 'technical_depth').
+        keywords: Optional list of keywords for heuristic scoring.
+    
+    Returns:
+        Score from 1-5.
+    """
+    scorer = SCORERS.get(dimension_key)
+    if scorer:
+        return scorer(row)
+    
+    # Fallback to keyword heuristics
+    if keywords:
+        text = get_text_blob(row)
+        return apply_keyword_heuristics(text, keywords)
+    
+    return 1  # Default score if no scorer and no keywords
+
+
+def score_contact(row: dict, dimensions: list[dict]) -> dict:
+    """Score all dimensions for a contact, return scores and tier.
+    
+    Args:
+        row: The contact/leaderboard row to score.
+        dimensions: List of dimension dicts with 'key', 'label', 'weight'.
+    
+    Returns:
+        Dict with:
+            - scores: {dimension_key: score} mapping
+            - composite: sum of all scores
+            - max: maximum possible score
+            - pct: composite as percentage of max
+            - tier: tier label based on percentage
+    """
+    scores = {}
+    for dim in dimensions:
+        key = dim["key"]
+        keywords = dim.get("keywords")  # Optional custom keywords
+        scores[key] = score_dimension(row, key, keywords)
+    
+    composite = sum(scores.values())
+    max_possible = len(dimensions) * 5
+    pct = composite / max_possible if max_possible else 0
+    
+    if pct >= 0.8:
+        tier = "🔴 Top Tier"
+    elif pct >= 0.6:
+        tier = "🟡 Mid Tier"
+    else:
+        tier = "⚪ Speculative"
+    
+    return {
+        "scores": scores,
+        "composite": composite,
+        "max": max_possible,
+        "pct": pct,
+        "tier": tier,
+    }
+
+
+def evidence_sentence(row: dict, dim_key: str) -> str:
+    """Generate a brief evidence sentence for a dimension score.
+    
+    Args:
+        row: The data row.
+        dim_key: The dimension key.
+    
+    Returns:
+        Human-readable evidence string.
+    """
+    text = get_text_blob(row)
+    
+    if dim_key == "technical_depth":
+        hits = get_matching_keywords(text, TECH_KEYWORDS, limit=5)
+        if hits:
+            return f"Keywords matched: {', '.join(hits)}."
+        return "No technical keywords found in profile."
+    
+    if dim_key == "forecasting":
+        hits = get_matching_keywords(text, QUANT_KEYWORDS, limit=5)
+        if hits:
+            return f"Keywords matched: {', '.join(hits)}."
+        return "No quantitative keywords found in profile."
+    
+    if dim_key == "operational_reliability":
+        lsm = row.get("leaderboard_score_month") or 0
+        mt = row.get("monthly_tasks") or 0
+        return f"Leaderboard score (month): {lsm}, monthly tasks: {mt}."
+    
+    if dim_key == "engagement_consistency":
+        wr = row.get("weekly_rewards") or 0
+        lsw = row.get("leaderboard_score_week") or 0
+        return f"Weekly rewards: {wr:,.0f}, leaderboard score (week): {lsw}."
+    
+    return "No evidence available."
+
+
+def infer_role(row: dict) -> str:
+    """Infer a likely role based on profile keywords.
+    
+    Args:
+        row: The data row with capabilities, summary, etc.
+    
+    Returns:
+        Role string like 'Signal / Quant', 'Infrastructure', etc.
+    """
+    text = get_text_blob(row)
+    
+    if any(kw in text for kw in ["trading", "quant", "alpha", "signal"]):
+        return "Signal / Quant"
+    if any(kw in text for kw in ["infrastructure", "devops", "kubernetes", "docker"]):
+        return "Infrastructure"
+    if any(kw in text for kw in ["smart contract", "solidity", "evm", "blockchain"]):
+        return "Protocol Engineer"
+    if any(kw in text for kw in ["research", "analytics", "data science"]):
+        return "Researcher"
+    
+    return "Contributor"

--- a/pf_scout/scoring.py
+++ b/pf_scout/scoring.py
@@ -4,7 +4,6 @@ This module provides reusable scoring functions for evaluating contacts
 against rubric dimensions. Used by prospect, report, and other commands.
 """
 
-from typing import Any
 
 # ---------------------------------------------------------------------------
 # Default keyword sets for heuristic scoring
@@ -43,10 +42,10 @@ DEFAULT_DIMENSIONS = [
 
 def get_text_blob(row: dict) -> str:
     """Concatenate all text fields from a leaderboard row for keyword search.
-    
+
     Args:
         row: A leaderboard row dictionary with summary, capabilities, etc.
-    
+
     Returns:
         Lowercased concatenated text for keyword matching.
     """
@@ -68,11 +67,11 @@ def get_text_blob(row: dict) -> str:
 
 def apply_keyword_heuristics(text: str, keywords: list[str]) -> int:
     """Count keyword hits and convert to a 1-5 score.
-    
+
     Args:
         text: The lowercased text to search in.
         keywords: List of keywords to look for.
-    
+
     Returns:
         Score from 1-5 based on number of keyword matches.
     """
@@ -90,11 +89,11 @@ def apply_keyword_heuristics(text: str, keywords: list[str]) -> int:
 
 def count_keyword_hits(text: str, keywords: list[str]) -> int:
     """Count how many distinct keywords appear in text.
-    
+
     Args:
         text: The lowercased text to search in.
         keywords: List of keywords to look for.
-    
+
     Returns:
         Number of keyword matches.
     """
@@ -103,12 +102,12 @@ def count_keyword_hits(text: str, keywords: list[str]) -> int:
 
 def get_matching_keywords(text: str, keywords: list[str], limit: int = 5) -> list[str]:
     """Get list of matching keywords from text.
-    
+
     Args:
         text: The lowercased text to search in.
         keywords: List of keywords to look for.
         limit: Maximum number of matches to return.
-    
+
     Returns:
         List of matched keywords (up to limit).
     """
@@ -121,10 +120,10 @@ def get_matching_keywords(text: str, keywords: list[str], limit: int = 5) -> lis
 
 def score_technical_depth(row: dict) -> int:
     """Score technical depth (1-5) based on tech keywords and sybil score.
-    
+
     Args:
         row: Leaderboard row with capabilities, summary, sybil_score.
-    
+
     Returns:
         Score from 1-5.
     """
@@ -137,10 +136,10 @@ def score_technical_depth(row: dict) -> int:
 
 def score_forecasting(row: dict) -> int:
     """Score quantitative/forecasting potential (1-5).
-    
+
     Args:
         row: Leaderboard row with capabilities, alignment_score, monthly_rewards.
-    
+
     Returns:
         Score from 1-5.
     """
@@ -155,10 +154,10 @@ def score_forecasting(row: dict) -> int:
 
 def score_operational_reliability(row: dict) -> int:
     """Score operational reliability (1-5) based on leaderboard metrics.
-    
+
     Args:
         row: Leaderboard row with leaderboard_score_month, monthly_tasks, rewards.
-    
+
     Returns:
         Score from 1-5.
     """
@@ -186,10 +185,10 @@ def score_operational_reliability(row: dict) -> int:
 
 def score_engagement_consistency(row: dict) -> int:
     """Score engagement consistency (1-5) based on weekly activity.
-    
+
     Args:
         row: Leaderboard row with weekly_rewards, leaderboard_score_week.
-    
+
     Returns:
         Score from 1-5.
     """
@@ -227,37 +226,37 @@ SCORERS = {
 
 def score_dimension(row: dict, dimension_key: str, keywords: list[str] | None = None) -> int:
     """Score a single dimension (1-5).
-    
+
     If a registered scorer exists for the dimension_key, use it.
     Otherwise, fall back to keyword heuristics if keywords are provided.
-    
+
     Args:
         row: The data row to score.
         dimension_key: The dimension identifier (e.g., 'technical_depth').
         keywords: Optional list of keywords for heuristic scoring.
-    
+
     Returns:
         Score from 1-5.
     """
     scorer = SCORERS.get(dimension_key)
     if scorer:
         return scorer(row)
-    
+
     # Fallback to keyword heuristics
     if keywords:
         text = get_text_blob(row)
         return apply_keyword_heuristics(text, keywords)
-    
+
     return 1  # Default score if no scorer and no keywords
 
 
 def score_contact(row: dict, dimensions: list[dict]) -> dict:
     """Score all dimensions for a contact, return scores and tier.
-    
+
     Args:
         row: The contact/leaderboard row to score.
         dimensions: List of dimension dicts with 'key', 'label', 'weight'.
-    
+
     Returns:
         Dict with:
             - scores: {dimension_key: score} mapping
@@ -271,18 +270,18 @@ def score_contact(row: dict, dimensions: list[dict]) -> dict:
         key = dim["key"]
         keywords = dim.get("keywords")  # Optional custom keywords
         scores[key] = score_dimension(row, key, keywords)
-    
+
     composite = sum(scores.values())
     max_possible = len(dimensions) * 5
     pct = composite / max_possible if max_possible else 0
-    
+
     if pct >= 0.8:
         tier = "🔴 Top Tier"
     elif pct >= 0.6:
         tier = "🟡 Mid Tier"
     else:
         tier = "⚪ Speculative"
-    
+
     return {
         "scores": scores,
         "composite": composite,
@@ -294,52 +293,52 @@ def score_contact(row: dict, dimensions: list[dict]) -> dict:
 
 def evidence_sentence(row: dict, dim_key: str) -> str:
     """Generate a brief evidence sentence for a dimension score.
-    
+
     Args:
         row: The data row.
         dim_key: The dimension key.
-    
+
     Returns:
         Human-readable evidence string.
     """
     text = get_text_blob(row)
-    
+
     if dim_key == "technical_depth":
         hits = get_matching_keywords(text, TECH_KEYWORDS, limit=5)
         if hits:
             return f"Keywords matched: {', '.join(hits)}."
         return "No technical keywords found in profile."
-    
+
     if dim_key == "forecasting":
         hits = get_matching_keywords(text, QUANT_KEYWORDS, limit=5)
         if hits:
             return f"Keywords matched: {', '.join(hits)}."
         return "No quantitative keywords found in profile."
-    
+
     if dim_key == "operational_reliability":
         lsm = row.get("leaderboard_score_month") or 0
         mt = row.get("monthly_tasks") or 0
         return f"Leaderboard score (month): {lsm}, monthly tasks: {mt}."
-    
+
     if dim_key == "engagement_consistency":
         wr = row.get("weekly_rewards") or 0
         lsw = row.get("leaderboard_score_week") or 0
         return f"Weekly rewards: {wr:,.0f}, leaderboard score (week): {lsw}."
-    
+
     return "No evidence available."
 
 
 def infer_role(row: dict) -> str:
     """Infer a likely role based on profile keywords.
-    
+
     Args:
         row: The data row with capabilities, summary, etc.
-    
+
     Returns:
         Role string like 'Signal / Quant', 'Infrastructure', etc.
     """
     text = get_text_blob(row)
-    
+
     if any(kw in text for kw in ["trading", "quant", "alpha", "signal"]):
         return "Signal / Quant"
     if any(kw in text for kw in ["infrastructure", "devops", "kubernetes", "docker"]):
@@ -348,5 +347,5 @@ def infer_role(row: dict) -> str:
         return "Protocol Engineer"
     if any(kw in text for kw in ["research", "analytics", "data science"]):
         return "Researcher"
-    
+
     return "Contributor"


### PR DESCRIPTION
## Summary
Implements Phase 1 of the productization roadmap: core UX commands.

## Changes

### Issue #7: `list` command ✅
- `pf-scout list` — show all contacts with latest scores
- `--tier top|mid|speculative|low` filtering
- `--rubric path.yaml` filter by rubric
- `--format text|json|csv` output formats
- `--limit N` pagination

### Issue #8: `export` command ✅
- `pf-scout export --output file.json` — full JSON export
- `--anonymize` — redact personal identifiers
- `--include-private` — include private notes

### Issue #9: `note` command ✅
- `pf-scout note <identifier> "text"` — add note
- `--private` marks note as private
- Updated `show` command with `--notes` flag

### Issue #10: Progress indicators ✅
- `seed github`: progress bar for identifier processing
- `update --all`: progress bar for contact updates

## Testing
- Python syntax validated
- All existing imports resolved

Closes #7, #8, #9, #10